### PR TITLE
Support enabling/disabling of systemd and sample code

### DIFF
--- a/Samples.am
+++ b/Samples.am
@@ -35,6 +35,8 @@
 # QAT Sample Code #
 ###################
 
+if SAMPLES
+
 COMMON_SAMPLE_CFLAGS = -D USER_SPACE \
     -D_GNU_SOURCE \
     -DSC_ENABLE_DYNAMIC_COMPRESSION \
@@ -381,5 +383,7 @@ sample-uninstall:
 	@rm -rf $(datadir)/qat/calgary32
 	@rm -rf $(datadir)/qat/canterbury
 	@rmdir --ignore-fail-on-non-empty $(datadir)/qat
+
+endif
 
 .PHONY: samples samples-install sample-uninstall

--- a/configure.ac
+++ b/configure.ac
@@ -76,24 +76,40 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])],
 CFLAGS="$saved_cflags"
 AC_SUBST(NO_UNUSED_CMDLINE_ARG_CFLAGS)
 
+# Check location of systemd unit files
+PKG_PROG_PKG_CONFIG
+
 # Check for systemd.
 AS_IF([test "x$PKGCONFIG" = "x"],
     [AC_MSG_ERROR(pkg-config not found.)],
     [AC_MSG_CHECKING(for systemd)
      AS_IF([$PKGCONFIG --exists systemd],
-        [AC_MSG_RESULT(yes)],
-        [AC_MSG_RESULT(no); AC_MSG_ERROR(systemd not found.)]
+        [AC_MSG_RESULT(yes); have_systemd="yes"],
+        [AC_MSG_RESULT(no);  have_systemd="no"]
     )]
 )
 
+AC_ARG_ENABLE(systemd,
+        AC_HELP_STRING([--enable-systemd], [Enable systemd support]),
+	[enable_systemd=${enableval}], [enable_systemd="yes"])
+if (test "${have_systemd}" = "no"); then
+    if (test "${enable_systemd}" != "no" ); then
+        AC_MSG_ERROR(systemd not found)
+    fi
+else
+    AC_MSG_CHECKING(whether to use systemd)
+    AC_MSG_RESULT(${enable_systemd})
+fi
+AM_CONDITIONAL(HAVE_SYSTEMD, test "${enable_systemd}" != "no")
 
-# Check location of systemd unit files
-PKG_PROG_PKG_CONFIG
 AC_ARG_WITH([systemdsystemunitdir],
         AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files]),
         [], [with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])
 AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])
-AM_CONDITIONAL(HAVE_SYSTEMD, [test -n "$with_systemdsystemunitdir"])
+
+AS_IF([test "${enable_systemd}" != "no"],
+	    [AC_MSG_CHECKING(systemd unit directory); AC_MSG_RESULT(${systemdsystemunitdir})],
+	    [])
 
 
 # MAX_MR
@@ -168,10 +184,14 @@ AC_ARG_ENABLE(service,
     AS_HELP_STRING([--enable-service], [Automatically enables systemd service during installation.]),
     [service=true], [service=false]
 )
-AM_CONDITIONAL([SERVICE_AC], [test x$service = xtrue])
+AM_CONDITIONAL([SERVICE_AC], [test x$service = xtrue -a x$enable_systemd != xno ])
 
 # Config files.
-AC_CONFIG_FILES([Makefile quickassist/utilities/service/qat.service qatlib.spec])
+AC_CONFIG_FILES([Makefile qatlib.spec])
+if test x$enable_systemd != xno
+then
+	AC_CONFIG_FILES([quickassist/utilities/service/qat.service])
+fi
 
 # Substitutions in spec file
 AC_SUBST([PACKAGE])

--- a/configure.ac
+++ b/configure.ac
@@ -111,6 +111,13 @@ AS_IF([test "${enable_systemd}" != "no"],
 	    [AC_MSG_CHECKING(systemd unit directory); AC_MSG_RESULT(${systemdsystemunitdir})],
 	    [])
 
+# SAMPLES
+AC_ARG_ENABLE(samples,
+        AC_HELP_STRING([--enable-samples], [Create sample programs]),
+	[enable_samples=${enableval}], [enable_samples="yes"])
+AC_MSG_CHECKING(whether to build samples)
+AC_MSG_RESULT(${enable_samples})
+AM_CONDITIONAL(SAMPLES, test "${enable_samples}" != "no")
 
 # MAX_MR
 AC_ARG_VAR(MAX_MR, [Number of Miller Rabin rounds for prime operations. Setting this to a smaller value reduces the memory usage required by the driver (default: 50).])


### PR DESCRIPTION
In our project(s) creating various cloud images we are mostly interested in the libraries and not so much about systemd support or sample code creation. Therefore the two patches, each adding an enable/disable switch to configure for including or excluding these. The default is still to enable both systemd and sample code, thus there are no configuration changes needed in other projects that already use qatlib.