### PR TITLE
Add workflow - Linux build with gcc

### DIFF
--- a/.github/workflows/linux_build_gcc.yml
+++ b/.github/workflows/linux_build_gcc.yml
@@ -1,0 +1,27 @@
+name: Linux Build gcc
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - run: sudo apt install -y automake libtool pkg-config libssl-dev libz-dev yasm
+    - uses: actions/checkout@v3
+      with:
+        repository: intel/qatlib
+    
+    - name: autogen
+      run: ACLOCAL_PATH=/usr/share/aclocal ./autogen.sh
+      
+    - name: configure
+      run: ./configure
+           
+    - name: make
+      run: make -j


### PR DESCRIPTION
Add new workflow to the repo.
This builds QATlib on Linux with gcc for each PR and commit in main.