### PR TITLE
Update linux_build_gcc.yml

### DIFF
--- a/.github/workflows/linux_build_gcc.yml
+++ b/.github/workflows/linux_build_gcc.yml
@@ -13,15 +13,17 @@ jobs:
 
     steps:
     - run: sudo apt install -y automake libtool pkg-config libssl-dev libz-dev yasm
-    - uses: actions/checkout@v3
+
+    - name: Checkout repository using checkout action v3.1.0
+      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       with:
         repository: intel/qatlib
-    
+
     - name: autogen
       run: ACLOCAL_PATH=/usr/share/aclocal ./autogen.sh
-      
+
     - name: configure
       run: ./configure
-           
+
     - name: make
       run: make -j


### PR DESCRIPTION
Update linux_build_gcc.yml to pin the checkout GitHubAction by hash. Use version 3.1.0.
https://github.com/actions/checkout/releases/tag/v3.1.0

Signed-off-by: Giovanni Cabiddu <giovanni.cabiddu@intel.com>