### PR TITLE
Update permissions in linux_build_gcc workflow

### DIFF
--- a/.github/workflows/linux_build_gcc.yml
+++ b/.github/workflows/linux_build_gcc.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+    contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Set the token permission for the content in the linux gcc build workflow to read-only to avoid attacks that can lead to commit unreviewed code: https://github.com/ossf/scorecard/blob/c40859202d739b31fd060ac5b30d17326cd74275/docs/checks.md#token-permissions

Signed-off-by: Giovanni Cabiddu <giovanni.cabiddu@intel.com>