### PR TITLE
Workflows: remove dependency with yasm

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
 
     # Install dependencies and build
     - name: Install dependencies
-      run: sudo apt install -y automake libtool pkg-config libssl-dev libz-dev yasm nasm
+      run: sudo apt install -y automake libtool pkg-config libssl-dev libz-dev nasm
 
     - name: autogen
       run: ACLOCAL_PATH=/usr/share/aclocal ./autogen.sh

--- a/.github/workflows/linux_build_gcc.yml
+++ b/.github/workflows/linux_build_gcc.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - run: sudo apt install -y automake libtool pkg-config libssl-dev libz-dev yasm nasm
+    - run: sudo apt install -y automake libtool pkg-config libssl-dev libz-dev nasm
 
     - name: Checkout repository using checkout action v3.1.0
       uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8


### PR DESCRIPTION
Update workflows to remove the dependency with the yasm assembler which was replaced by nasm in QATlib 22.07.2.

Signed-off-by: Giovanni Cabiddu <giovanni.cabiddu@intel.com>