### PR TITLE
qatlib.spec.in: remove Provides line

### DIFF
--- a/qatlib.spec.in
+++ b/qatlib.spec.in
@@ -48,7 +48,6 @@ This package contains sample applications that use the Intel QuickAssists APIs.
 %package       service
 Summary:       A daemon for qatlib resources management
 Requires:      %{name}%{?_isa} = %{version}-%{release}
-Provides:      qatlib-service
 %{?systemd_requires}
 
 %description   service


### PR DESCRIPTION
The line `Provides: qatlib-service` is redundant since rpm builder records a package's own `Provides:` automatically. In addition it causes an rpm lint error. Remove it.

Signed-off-by: Giovanni Cabiddu <giovanni.cabiddu@intel.com>