### PR TITLE
Fix a wide range of spelling mistakes and typos

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -145,7 +145,7 @@ Compilation and installation - quickstart instructions
         # Install qatlib-tests rpm
         sudo dnf install -y qatlib-tests
 
-        # cpa_sample_code requires a mimimum of 500MB to run its compression demo
+        # cpa_sample_code requires a minimum of 500MB to run its compression demo
         # To increase amount of locked memory for your user to 500MB:
         sudo cp /etc/security/limits.conf /etc/security/limits.conf.qatlib_bak
         echo `whoami` - memlock 500000  | sudo tee -a /etc/security/limits.conf > /dev/null
@@ -186,7 +186,7 @@ Compilation and installation - quickstart instructions
 
         # You can also follow these steps to try out a sample application:
 
-        # cpa_sample_code requires a mimimum of 500MB to run its compression demo
+        # cpa_sample_code requires a minimum of 500MB to run its compression demo
         # To increase the amount of locked memory for your user to 500MB:
         sudo cp /etc/security/limits.conf /etc/security/limits.conf.qatlib_bak
         echo `whoami` - memlock 500000  | sudo tee -a /etc/security/limits.conf > /dev/null

--- a/quickassist/include/cpa_dev.h
+++ b/quickassist/include/cpa_dev.h
@@ -127,9 +127,9 @@ typedef struct _CpaDeviceInfo {
 	CpaBoolean dcEnabled;
     /**< Compression service enabled */
 	CpaBoolean cySymEnabled;
-    /**< Symetric crypto service enabled */
+    /**< Symmetric crypto service enabled */
 	CpaBoolean cyAsymEnabled;
-    /**< Asymetric crypto service enabled */
+    /**< Asymmetric crypto service enabled */
 	CpaBoolean inlineEnabled;
     /**< Inline service enabled */
 	Cpa32U deviceMemorySizeAvailable;

--- a/quickassist/include/dc/cpa_dc.h
+++ b/quickassist/include/dc/cpa_dc.h
@@ -1301,7 +1301,7 @@ cpaDcResetSession(const CpaInstanceHandle dcInstance,
  *      This function will reset the internal xxHash state maintained within a
  *      session. This would be used in conjunction with the
  *      CpaDcSessionSetupData.accumulateXXHash flag being set to TRUE for this
- *      session. It will enable reseting (reinitialising) just the xxHash
+ *      session. It will enable resetting (reinitialising) just the xxHash
  *      calculation back to the state when the session was first initialised.
  *
  * @context
@@ -2298,7 +2298,7 @@ cpaDcNsDecompressData( CpaInstanceHandle dcInstance,
  *          - Content size = 0
  *          - Dictionary ID = 0
  *          - Header checksum = 1 byte representing the second byte of the
- *                              XXH32 of the frame decriptor field.
+ *                              XXH32 of the frame descriptor field.
  *
  *      The counter parameter will be set to the number of bytes added to the
  *      buffer. The pData will be not be changed.

--- a/quickassist/include/dc/cpa_dc_chain.h
+++ b/quickassist/include/dc/cpa_dc_chain.h
@@ -195,7 +195,7 @@ typedef enum _CpaDcChainOperations
     /**< 3 operations for chaining:
      * 1st operation is to perform compression on plain text
      * 2nd operation is to perform AEAD encryption compressed text
-     * 3rd operation is to perfom hash on compressed & encrypted text
+     * 3rd operation is to perform hash on compressed & encrypted text
      **< 3 entries in CpaDcChainSessionSetupData array:
      * 1st entry is for compression setup data
      * 2nd entry is for AEAD encryption setup data

--- a/quickassist/include/lac/cpa_cy_ec.h
+++ b/quickassist/include/lac/cpa_cy_ec.h
@@ -477,7 +477,7 @@ typedef struct _CpaCyEcGenericPointVerifyOpData {
  *****************************************************************************
  * @ingroup cpaCyEc
  *      EC Point Multiplication Operation Data for Edwards or
- *      Montgomery curves as specificied in RFC#7748.
+ *      Montgomery curves as specified in RFC#7748.
  *
  * @description
  *      This structure contains the operation data for the
@@ -516,7 +516,7 @@ typedef struct _CpaCyEcMontEdwdsPointMultiplyOpData {
     CpaFlatBuffer  k;
     /**< k scalar multiplier for the operation */
     CpaFlatBuffer  x;
-    /**< x value.  Used in scalar varable point multiplication operations.
+    /**< x value.  Used in scalar variable point multiplication operations.
      * Not required if the generator is True. Must be NULL if not required.
      * The size of the buffer MUST be 32B for 25519 curves and 64B for 448
      * curves */

--- a/quickassist/include/lac/cpa_cy_kpt.h
+++ b/quickassist/include/lac/cpa_cy_kpt.h
@@ -124,11 +124,11 @@ typedef enum CpaCyKptKeyManagementStatus_t
     CPA_CY_KPT_SUCCESS = 0,
     /**< Generic success status for all KPT wrapping key handling functions*/
     CPA_CY_KPT_LOADKEY_FAIL_QUOTA_EXCEEDED_PER_VFID,
-    /**< SWK count exceeds the configured maxmium value per VFID*/
+    /**< SWK count exceeds the configured maximum value per VFID*/
     CPA_CY_KPT_LOADKEY_FAIL_QUOTA_EXCEEDED_PER_PASID,
-    /**< SWK count exceeds the configured maxmium value per PASID*/
+    /**< SWK count exceeds the configured maximum value per PASID*/
     CPA_CY_KPT_LOADKEY_FAIL_QUOTA_EXCEEDED,
-    /**< SWK count exceeds the configured maxmium value when not scoped to
+    /**< SWK count exceeds the configured maximum value when not scoped to
     * VFID or PASID*/
     CPA_CY_KPT_SWK_FAIL_NOT_FOUND,
     /**< Unable to find SWK entry by handle */
@@ -303,7 +303,7 @@ typedef struct CpaCyKptRsaPrivateKeyRep1_t
  *      describing the RSA private key. The quintuple of p, q, dP, dQ, and qInv
  *      (explained below and in the spec) are required for the second
  *      representation. For KPT the parameters are Encrypted
- *      with the assoicated SWK as follows:
+ *      with the associated SWK as follows:
  *      Encrypt - AES-256-GCM (Key, AAD, Input)
  *      "||" - denotes concatenation
  *      Key = SWK
@@ -554,7 +554,7 @@ typedef struct CpaCyKptEcdsaSignRSOpData_t
   * @param[out] pDevCredential       Device Per-Part public key
   * @param[out] pKptStatus           One of the status codes denoted in the
   *                                  enumerate type CpaCyKptKeyManagementStatus
-  *              CPA_CY_KPT_SUCCESS  Device credentials retreived successfully
+  *              CPA_CY_KPT_SUCCESS  Device credentials retrieved successfully
   *              CPA_CY_KPT_FAILED   Operation failed
   *
   * @retval CPA_STATUS_SUCCESS       Function executed successfully.
@@ -610,11 +610,11 @@ typedef struct CpaCyKptEcdsaSignRSOpData_t
   *                                 enumerate type CpaCyKptKeyManagementStatus
   *   CPA_CY_KPT_SUCCESS  Key Loaded successfully
   *   CPA_CY_KPT_LOADKEY_FAIL_QUOTA_EXCEEDED_PER_VFID
-  *       SWK count exceeds the configured maxmium value per VFID
+  *       SWK count exceeds the configured maximum value per VFID
   *   CPA_CY_KPT_LOADKEY_FAIL_QUOTA_EXCEEDED_PER_PASID
-  *       SWK count exceeds the configured maxmium value per PASID
+  *       SWK count exceeds the configured maximum value per PASID
   *   CPA_CY_KPT_LOADKEY_FAIL_QUOTA_EXCEEDED
-  *       SWK count exceeds the configured maxmium value when not scoped to
+  *       SWK count exceeds the configured maximum value when not scoped to
   *       VFID or PASID
   *   CPA_CY_KPT_FAILED   Operation failed due to unspecified reason
   *

--- a/quickassist/include/lac/cpa_cy_sym.h
+++ b/quickassist/include/lac/cpa_cy_sym.h
@@ -681,7 +681,7 @@ typedef struct _CpaCySymSessionSetupData  {
     CpaCyPriority sessionPriority;
     /**< Priority of this session */
     CpaCySymOp symOperation;
-    /**< Operation to perfom */
+    /**< Operation to perform */
     CpaCySymCipherSetupData cipherSetupData;
     /**< Cipher Setup Data for the session. This member is ignored for the
      * CPA_CY_SYM_OP_HASH operation. */
@@ -1220,7 +1220,7 @@ cpaCySymSessionCtxGetSize(const CpaInstanceHandle instanceHandle,
  *      minimum memory size needed to support all possible setup data parameter 
  *      combinations. cpaCySymSessionCtxGetDynamicSize() will return the 
  *      minimum memory size needed to support the specific session setup 
- *      data parmeters provided. This size may be different for different setup
+ *      data parameters provided. This size may be different for different setup
  *      data parameters.
  *
  * @context

--- a/quickassist/include/lac/cpa_cy_sym_dp.h
+++ b/quickassist/include/lac/cpa_cy_sym_dp.h
@@ -402,7 +402,7 @@ typedef struct _CpaCySymDpOpData {
  * @description
  *      This is the callback function prototype. The callback function is
  *      registered by the application using the @ref cpaCySymDpRegCbFunc
- *      function call, and called back on completion of asycnhronous
+ *      function call, and called back on completion of asynchronous
  *      requests made via calls to @ref cpaCySymDpEnqueueOp or @ref
  *      cpaCySymDpEnqueueOpBatch.
  *
@@ -454,7 +454,7 @@ typedef void (*CpaCySymDpCbFunc)(CpaCySymDpOpData *pOpData,
  * @description
  *      This function allows a completion callback function to be registered.
  *      The registered callback function is invoked on completion of
- *      asycnhronous requests made via calls to @ref cpaCySymDpEnqueueOp
+ *      asynchronous requests made via calls to @ref cpaCySymDpEnqueueOp
  *      or @ref cpaCySymDpEnqueueOpBatch.
  *
  *      If a callback function was previously registered, it is overwritten.
@@ -585,7 +585,7 @@ cpaCySymDpSessionCtxGetSize(const CpaInstanceHandle instanceHandle,
  *      minimum memory size needed to support all possible setup data parameter 
  *      combinations. cpaCySymDpSessionCtxGetDynamicSize() will return the 
  *      minimum memory size needed to support the specific session setup 
- *      data parmeters provided. This size may be different for different setup
+ *      data parameters provided. This size may be different for different setup
  *      data parameters.
  *
  * @context

--- a/quickassist/lookaside/access_layer/include/icp_adf_init.h
+++ b/quickassist/lookaside/access_layer/include/icp_adf_init.h
@@ -83,7 +83,7 @@ typedef enum icp_adf_ringInfoOperation_e
 } icp_adf_ringInfoOperation_t;
 
 /*
- * Ring generic serivce info private data
+ * Ring generic service info private data
  */
 typedef enum icp_adf_ringInfoService_e
 {

--- a/quickassist/lookaside/access_layer/include/icp_adf_transport.h
+++ b/quickassist/lookaside/access_layer/include/icp_adf_transport.h
@@ -167,7 +167,7 @@ CpaStatus icp_adf_getNumAvailDynInstance(icp_accel_dev_t *accel_dev,
  * Get a file descriptor for a particular transaction handle.
  * If more than one transaction handler
  * are ever present, this will need to be refactored to
- * return the appropiate fd of the appropiate bank.
+ * return the appropriate fd of the appropriate bank.
  *
  * Returns:
  *   CPA_STATUS_SUCCESS   on success

--- a/quickassist/lookaside/access_layer/include/icp_buffer_desc.h
+++ b/quickassist/lookaside/access_layer/include/icp_buffer_desc.h
@@ -85,7 +85,7 @@
 
 typedef Cpa64U icp_qat_addr_width_t;
 
-/* Alignement constraint of the buffer list. */
+/* Alignment constraint of the buffer list. */
 #define ICP_DESCRIPTOR_ALIGNMENT_BYTES 8
 
 /**
@@ -96,7 +96,7 @@ typedef Cpa64U icp_qat_addr_width_t;
  *
  * @description
  *      A QAT friendly buffer descriptor.
- *      All buffer descriptor described in this structure are physcial
+ *      All buffer descriptor described in this structure are physical
  *      and are 64 bit wide.
  *
  *      Updates in the CpaFlatBuffer should be also reflected in this
@@ -121,7 +121,7 @@ typedef struct icp_flat_buffer_desc_s
  *
  * @description
  *      A QAT friendly buffer descriptor.
- *      All buffer descriptor described in this structure are physcial
+ *      All buffer descriptor described in this structure are physical
  *      and are 64 bit wide.
  *
  *      Updates in the CpaBufferList should be also reflected in this structure

--- a/quickassist/lookaside/access_layer/include/icp_sal_user.h
+++ b/quickassist/lookaside/access_layer/include/icp_sal_user.h
@@ -513,7 +513,7 @@ CpaStatus icp_sal_find_new_devices(void);
  * @assumptions
  *      None
  * @sideEffects
- *      In case a device has beed stoped or restarted the application
+ *      In case a device has been stopped or restarted the application
  *      will get restarting/stop/shutdown events
  * @reentrant
  *      No

--- a/quickassist/lookaside/access_layer/src/common/compression/dc_chain.c
+++ b/quickassist/lookaside/access_layer/src/common/compression/dc_chain.c
@@ -203,7 +203,7 @@ dcChainSession_CheckSessionType(const CpaDcChainSessionSetupData *pSessionData,
  * @description
  *      Check that all the parameters defined in the pSessionData are valid
  *
- * @param[in]       operation        Chaining opration
+ * @param[in]       operation        Chaining operation 
  * @param[in]       numSessions      Number of chaining sessions
  * @param[in]       pSessionData     Pointer to an array of
  *                                   CpaDcChainSessionSetupData
@@ -528,7 +528,7 @@ CpaStatus dcChainSession_PopulateSymSetupData(
  * @description
  *      Build symmetric crypto template for chaining operation
  *      it is called by dcChainSession_InitSymCrypto to construct
- *      cryto request descriptor
+ *      crypto request descriptor
  *
  * @param[in]       instanceHandle     Instance handle
  * @param[in]       pSessionCtx        Symmetric crypto session content
@@ -2220,7 +2220,7 @@ dcChainCallback_ProcessComp(dc_compression_cookie_t *pDcCookie,
  *
  * @description
  *      Process chaining result, it is called at dcCompression_ProcessCallback
- *      when repsonse type is chaining
+ *      when response type is chaining
  *
  * @param[in,out]   pRespMsg     Pointer to firmware response message
  *

--- a/quickassist/lookaside/access_layer/src/common/compression/dc_datapath.c
+++ b/quickassist/lookaside/access_layer/src/common/compression/dc_datapath.c
@@ -974,7 +974,7 @@ STATIC CpaStatus dcCheckOpData(sal_compression_service_t *pService,
     if (CPA_TRUE == pOpData->integrityCrcCheck && NULL == pOpData->pCrcData)
     {
         LAC_INVALID_PARAM_LOG("Integrity CRC data structure "
-                              "not intialized in CpaDcOpData");
+                              "not initialized in CpaDcOpData");
         return CPA_STATUS_INVALID_PARAM;
     }
 

--- a/quickassist/lookaside/access_layer/src/common/compression/include/dc_chain.h
+++ b/quickassist/lookaside/access_layer/src/common/compression/include/dc_chain.h
@@ -290,7 +290,7 @@ CpaStatus dcChainPerformOp(CpaInstanceHandle dcInstance,
  * @description
  *      Chaining response callback
  *
- * @param[in]       pRespMsg         Chaining response discriptor
+ * @param[in]       pRespMsg         Chaining response descriptor
  *
  * @retval none
  *

--- a/quickassist/lookaside/access_layer/src/common/compression/include/dc_header_footer_lz4.h
+++ b/quickassist/lookaside/access_layer/src/common/compression/include/dc_header_footer_lz4.h
@@ -117,7 +117,7 @@ CpaStatus dc_lz4_generate_header(const CpaFlatBuffer *dest_buff,
  *      Generate the LZ4 footer.
  *
  * @description
- *      This function generates tha LZ4 compression footer.
+ *      This function generates the LZ4 compression footer.
  *
  * @param[in]   dest_buff        Pointer to the destination buffer where
  *                               the LZ4 footer will be written to.

--- a/quickassist/lookaside/access_layer/src/common/crypto/asym/dsa/lac_dsa.c
+++ b/quickassist/lookaside/access_layer/src/common/crypto/asym/dsa/lac_dsa.c
@@ -3280,6 +3280,6 @@ void LacDsa_StatsShow(CpaInstanceHandle instanceHandle)
 #else
     osalLog(OSAL_LOG_LVL_USER,
             OSAL_LOG_DEV_STDOUT,
-            "  DSA not suppported \n");
+            "  DSA not supported \n");
 #endif
 }

--- a/quickassist/lookaside/access_layer/src/common/crypto/asym/ecc/lac_ec.c
+++ b/quickassist/lookaside/access_layer/src/common/crypto/asym/ecc/lac_ec.c
@@ -46,7 +46,7 @@
  * @lld_start
  *
  * @lld_overview
- * This file implements Elliptic Curve api funcitons.
+ * This file implements Elliptic Curve api functions.
  * @lld_dependencies
  * - \ref LacAsymCommonQatComms "PKE QAT Comms" : For creating and sending
  * messages to the QAT
@@ -1280,7 +1280,7 @@ CpaStatus LacEcc_CommonPathUnoptimised(
         {
             /* In GF2 9QW and 4QW special cases h has already been
                 checked (and is known by MMP) and the size of k has already
-                been checked in getRange function so just need to chec
+                been checked in getRange function so just need to check
                 8QW case */
             Cpa32U bufferBits = LAC_BYTES_TO_BITS(LAC_EC_SIZE_QW9_IN_BYTES) - 1;
             if (bufferBits < requiredBits)

--- a/quickassist/lookaside/access_layer/src/common/crypto/asym/ecc/lac_ec_montedwds.c
+++ b/quickassist/lookaside/access_layer/src/common/crypto/asym/ecc/lac_ec_montedwds.c
@@ -46,7 +46,7 @@
  * @lld_start
  *
  * @lld_overview
- * This file implements Elliptic Curve Montgomery and Edwards api funcitons.
+ * This file implements Elliptic Curve Montgomery and Edwards api functions.
  * @lld_dependencies
  * - \ref LacAsymCommonQatComms "PKE QAT Comms" : For creating and sending
  * messages to the QAT

--- a/quickassist/lookaside/access_layer/src/common/crypto/asym/ecc/lac_ecdh.c
+++ b/quickassist/lookaside/access_layer/src/common/crypto/asym/ecc/lac_ecdh.c
@@ -603,7 +603,7 @@ CpaStatus cpaCyEcdhPointMultiply(const CpaInstanceHandle instanceHandle_in,
             }
             else
             {
-                /* In GF2 9QW and 4QW speacial cases h has already been
+                /* In GF2 9QW and 4QW special cases h has already been
                    checked (and is known by MMP) and the size of k has already
                    been checked in getRange function so just need to check
                    8QW case */

--- a/quickassist/lookaside/access_layer/src/common/crypto/asym/ecc/lac_ecdsa.c
+++ b/quickassist/lookaside/access_layer/src/common/crypto/asym/ecc/lac_ecdsa.c
@@ -1442,7 +1442,7 @@ CpaStatus cpaCyEcdsaSignS(const CpaInstanceHandle instanceHandle_in,
                                LAC_ECDSA_SIGNS_NUM_OUT_ARGS,
                                dataOperationSizeBytes);
 
-        /* Set memory to extrenally allocated */
+        /* Set memory to externally allocated */
         LAC_EC_SET_LIST_PARAMS(
             internalMemInList, LAC_ECDSA_SIGNS_NUM_IN_ARGS, CPA_FALSE);
         LAC_EC_SET_LIST_PARAMS(

--- a/quickassist/lookaside/access_layer/src/common/crypto/asym/include/lac_ln.h
+++ b/quickassist/lookaside/access_layer/src/common/crypto/asym/include/lac_ln.h
@@ -55,7 +55,7 @@
  * even/odd combinations of the input data before choosing the flavour of the
  * QAT function.
  *
- * Finaly the input/output argument lists are constructed before calling the PKE
+ * Finally the input/output argument lists are constructed before calling the PKE
  * QAT Comms layer to create and send a request to the QAT.
  *
  * Buffer alignment, and padding up to a chosen size (whole number of quadwords

--- a/quickassist/lookaside/access_layer/src/common/crypto/asym/include/lac_pke_mmp.h
+++ b/quickassist/lookaside/access_layer/src/common/crypto/asym/include/lac_pke_mmp.h
@@ -66,7 +66,7 @@
 
 /* A functionality id that is guaranteed to be invalid */
 #define LAC_PKE_INVALID_FUNC_ID 0
-/* A index for maping table that is guaranteed to be invalid */
+/* A index for mapping table that is guaranteed to be invalid */
 #define LAC_PKE_INVALID_INDEX -1
 /* Current total of input/output parameters */
 #define LAC_MAX_MMP_PARAMS 8

--- a/quickassist/lookaside/access_layer/src/common/crypto/asym/include/lac_pke_qat_comms.h
+++ b/quickassist/lookaside/access_layer/src/common/crypto/asym/include/lac_pke_qat_comms.h
@@ -331,7 +331,7 @@ void LacPke_MsgCallback(void *pRespMsg);
  *
  * @retval CPA_STATUS_SUCCESS       Successfully polled a memory pool with data
  *                                  that generate dummy responses.
- * @retval CPA_STATUS_RETRY         There are no inflight requests in the
+ * @retval CPA_STATUS_RETRY         There are no in-flight requests in the
  *                                  memory pool associated with the instance
  *
  ***************************************************************************/
@@ -405,7 +405,7 @@ void LacPke_InitAsymRequest(Cpa8U *pData, CpaInstanceHandle instanceHandle);
  * @param[in] pInternalInMemList pointer to a list of Booleans that indicate if
  *                              input data buffers passed to QAT are internally
  *                              or externally allocated. This information needs
- *                              to be tracked to ensure we use the corect
+ *                              to be tracked to ensure we use the correct
  *                              virt2phys function.
  * @param[in] pInternalInMemList pointer to a list of Booleans that indicate if
  *                              output data buffers passed to QAT are internally
@@ -488,7 +488,7 @@ CpaStatus LacPke_SendRequest(lac_pke_request_handle_t *pRequestHandle,
  * @param[in] pInternalInMemList pointer to a list of Booleans that indicate if
  *                              input data buffers passed to QAT are internally
  *                              or externally allocated. This information needs
- *                              to be tracked to ensure we use the corect
+ *                              to be tracked to ensure we use the correct
  *                              virt2phys function.
  * @param[in] pInternalInMemList pointer to a list of Booleans that indicate if
  *                              output data buffers passed to QAT are internally

--- a/quickassist/lookaside/access_layer/src/common/crypto/asym/include/lac_pke_utils.h
+++ b/quickassist/lookaside/access_layer/src/common/crypto/asym/include/lac_pke_utils.h
@@ -628,7 +628,7 @@ CpaStatus LacPke_GetBitLen(const CpaFlatBuffer *pBuffer, Cpa32U *pBitLen);
  * @description
  *      Return the size of the biggest number in provided buffers where n
  *      specify buffer count. If NULL pointer was detected is skipped from
- *      comparision.
+ *      comparison.
  *
  * @param[in]  n                number of buffers to compare
  * @param[in]  ...              list of pointers to a flat buffers

--- a/quickassist/lookaside/access_layer/src/common/crypto/asym/include/lac_prime.h
+++ b/quickassist/lookaside/access_layer/src/common/crypto/asym/include/lac_prime.h
@@ -262,7 +262,7 @@ CpaStatus LacPrimeParameterCheck(CpaCyPrimeTestCbFunc pCb,
  *      Prime Test Callback Function
  *
  * @description
- *     Called by PKE QAT COMMS when a response to a prime message is recevied
+ *     Called by PKE QAT COMMS when a response to a prime message is received
  *     from the QAT. This function increments stats and frees resources where
  *     appropriate before calling the client's callback.
  *

--- a/quickassist/lookaside/access_layer/src/common/crypto/asym/large_number/lac_ln.c
+++ b/quickassist/lookaside/access_layer/src/common/crypto/asym/large_number/lac_ln.c
@@ -260,7 +260,7 @@ Cpa32U LacGetBufferDataSizeInBytes(const CpaFlatBuffer *pBuffer)
 /**
  *******************************************************************************
  * @ingroup LacAsymLn
- *      Large Number Modular Exponentation internal callback function
+ *      Large Number Modular Exponentiation internal callback function
  ******************************************************************************/
 STATIC
 void LacLnModExpCallback(CpaStatus status,
@@ -345,7 +345,7 @@ CpaStatus LacLnModExpParameterCheck(const CpaCyGenFlatBufCbFunc pCb,
 /**
  ***************************************************************************
  * @ingroup LacAsymLn
- *      Large Number Modular Exponentation synchronous function
+ *      Large Number Modular Exponentiation synchronous function
  ***************************************************************************/
 STATIC CpaStatus LacLnModExpSyn(const CpaInstanceHandle instanceHandle,
                                 const CpaCyLnModExpOpData *pLnModExpOpData,
@@ -407,7 +407,7 @@ STATIC CpaStatus LacLnModExpSyn(const CpaInstanceHandle instanceHandle,
 /**
  *******************************************************************************
  * @ingroup LacAsymLn
- *      Large Number Modular Exponentation API function
+ *      Large Number Modular Exponentiation API function
  ******************************************************************************/
 CpaStatus cpaCyLnModExp(const CpaInstanceHandle instanceHandle_in,
                         const CpaCyGenFlatBufCbFunc pLnModExpCb,

--- a/quickassist/lookaside/access_layer/src/common/crypto/asym/pke_common/lac_pke_qat_comms.c
+++ b/quickassist/lookaside/access_layer/src/common/crypto/asym/pke_common/lac_pke_qat_comms.c
@@ -57,7 +57,7 @@
 * Include private header files
 ****************************************************************************
 */
-/* ADF incldues */
+/* ADF includes */
 #include "icp_adf_init.h"
 #include "icp_adf_transport.h"
 #include "icp_accel_devices.h"
@@ -156,7 +156,7 @@ void LacPke_HdrWrite(icp_qat_fw_pke_request_t *pMsg,
  *                        pointer to a list of Booleans that indicate if
  *                        input data buffers passed to QAT are internally or
  *                        externally allocated. This information needs to
- *                        be tracked to ensure we use the corect virt2phys
+ *                        be tracked to ensure we use the correct virt2phys
  *                        function, values may be updated by this function.
  * @param[in/out] pInternalOutMemList
  *                        pointer to a list of Booleans that indicate if
@@ -652,7 +652,7 @@ CpaStatus LacPke_CreateRequest(lac_pke_request_handle_t *pRequestHandle,
         /* clear the previous param info */
         LAC_OS_BZERO(&pReqData->paramInfo, sizeof(pReqData->paramInfo));
 
-        /* if the list is passed by the user, store it in prealocated memory */
+        /* if the list is passed by the user, store it in preallocated memory */
         if (NULL != pInArgSizeList)
         {
             memcpy(&pReqData->paramInfo.inArgSizeList,

--- a/quickassist/lookaside/access_layer/src/common/crypto/asym/pke_common/lac_pke_utils.c
+++ b/quickassist/lookaside/access_layer/src/common/crypto/asym/pke_common/lac_pke_utils.c
@@ -290,7 +290,7 @@ CpaStatus LacPke_GetBitPos(const CpaFlatBuffer *pBuffer,
     Cpa32U bitPosition = 0;
     Cpa8U msByte = 0;
 
-    /* Set zero flag false initally */
+    /* Set zero flag false initially*/
     *pIsZero = CPA_FALSE;
     /* Find the first non-zero byte from end of buffer */
     numBytes = LacPke_GetMinBytes(pBuffer);

--- a/quickassist/lookaside/access_layer/src/common/crypto/asym/prime/lac_prime.c
+++ b/quickassist/lookaside/access_layer/src/common/crypto/asym/prime/lac_prime.c
@@ -1163,7 +1163,7 @@ void LacPrime_StatsShow(CpaInstanceHandle instanceHandle)
     /* Parameter generation requests - PRIME stats */
     osalLog(OSAL_LOG_LVL_USER,
             OSAL_LOG_DEV_STDOUT,
-            BORDER " PRIME successfull requests:     %16llu " BORDER "\n" BORDER
+            BORDER " PRIME successful requests:      %16llu " BORDER "\n" BORDER
                    " PRIME failed requests:          %16llu " BORDER "\n" BORDER
                    " PRIME successfully completed:   %16llu " BORDER "\n" BORDER
                    " PRIME failed completion:        %16llu " BORDER "\n" BORDER

--- a/quickassist/lookaside/access_layer/src/common/crypto/asym/rsa/lac_rsa_encrypt.c
+++ b/quickassist/lookaside/access_layer/src/common/crypto/asym/rsa/lac_rsa_encrypt.c
@@ -109,7 +109,7 @@ static const Cpa32U lacRsaEncSizeIdMap[][LAC_PKE_NUM_COLUMNS] = {
 */
 
 /*
- * This function performs synchronious version of the RSA Encrypt.
+ * This function performs synchronous version of the RSA Encrypt.
  */
 STATIC CpaStatus LacRsa_EncryptSynch(const CpaInstanceHandle instanceHandle,
                                      const CpaCyRsaEncryptOpData *pEncryptData,
@@ -366,7 +366,7 @@ CpaStatus LacRsa_EncGetOpSizeAndCheck(const CpaInstanceHandle instanceHandle,
     LAC_CHECK_FLAT_BUFFER(&pEncryptData->pPublicKey->modulusN);
 #endif
     /* Check sizes. Operation size is the public key modulus length.
-     * Message and cipher buffers must be able to accomodate messages of
+     * Message and cipher buffers must be able to accommodate messages of
      * this length */
     *pOpSizeInBytes = LacPke_GetMinBytes(&(pEncryptData->pPublicKey->modulusN));
 #ifdef ICP_PARAM_CHECK

--- a/quickassist/lookaside/access_layer/src/common/crypto/asym/rsa/lac_rsa_keygen.c
+++ b/quickassist/lookaside/access_layer/src/common/crypto/asym/rsa/lac_rsa_keygen.c
@@ -122,7 +122,7 @@ static const Cpa32U lacRsaKp2SizeIdMap[][LAC_PKE_NUM_COLUMNS] = {
 */
 
 /*
- * This function performs synchronious version of the RSA Key Gen.
+ * This function performs synchronous version of the RSA Key Gen.
  */
 STATIC CpaStatus LacRsa_KeyGenSync(const CpaInstanceHandle instanceHandle,
                                    const CpaCyRsaKeyGenOpData *pKeyGenData,
@@ -130,7 +130,7 @@ STATIC CpaStatus LacRsa_KeyGenSync(const CpaInstanceHandle instanceHandle,
                                    CpaCyRsaPublicKey *pPublicKey);
 
 /*
- * This function is the synchronious callback function.
+ * This function is the synchronous callback function.
  */
 STATIC
 void LacRsa_KeyGenSyncCb(void *pCallbackTag,

--- a/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_session.h
+++ b/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_session.h
@@ -115,7 +115,7 @@
  * while there are requests in flight.
  *
  * <b>Reference Count</b>\n
- * - The perform funcion increments the reference count for the session.
+ * - The perform function increments the reference count for the session.
  * - The callback function decrements the reference count for the session.
  * - The Remove function checks the reference count to ensure that it is 0.
  *
@@ -294,14 +294,14 @@ typedef struct lac_session_desc_s
     /**< Cipher slice type to be used, set at init session time */
     Cpa8U cipherAesXtsKey1Forward[LAC_CIPHER_AES_XTS_KEY_MAX_LENGTH];
     /**< Cached AES XTS Forward key
-     * For CPM2.0 AES XTS key convertion need to be done in SW.
+     * For CPM2.0 AES XTS key conversion need to be done in SW.
      * Because use can update session direction at any time,
      * also forward key needs to be cached
      */
     Cpa8U cipherAesXtsKey1Reverse[LAC_CIPHER_AES_XTS_KEY_MAX_LENGTH];
     /**< AES XTS Reverse key
-     * For CPM2.0 AES XTS key convertion need to be done in SW.
-     * Reverse key always will be calcilated at session setup time and
+     * For CPM2.0 AES XTS key conversion need to be done in SW.
+     * Reverse key always will be calculated session setup time and
      * cached to be used when needed */
     Cpa8U cipherAesXtsKey2[LAC_CIPHER_AES_XTS_KEY_MAX_LENGTH];
     /**< For AES XTS session need to store Key2 value in order to generate tweak
@@ -464,14 +464,14 @@ typedef struct lac_session_desc_d1_s
     /**< Cipher slice type to be used, set at init session time */
     Cpa8U cipherAesXtsKey1Forward[LAC_CIPHER_AES_XTS_KEY_MAX_LENGTH];
     /**< Cached AES XTS Forward key
-     * For CPM2.0 AES XTS key convertion need to be done in SW.
+     * For CPM2.0 AES XTS key conversion need to be done in SW.
      * Because use can update session direction at any time,
      * also forward key needs to be cached
      */
     Cpa8U cipherAesXtsKey1Reverse[LAC_CIPHER_AES_XTS_KEY_MAX_LENGTH];
     /**< AES XTS Reverse key
-     * For CPM2.0 AES XTS key convertion need to be done in SW.
-     * Reverse key always will be calcilated at session setup time and
+     * For CPM2.0 AES XTS key conversion need to be done in SW.
+     * Reverse key always will be calculated at session setup time and
      * cached to be used when needed */
     Cpa8U cipherAesXtsKey2[LAC_CIPHER_AES_XTS_KEY_MAX_LENGTH];
     /**< For AES XTS session need to store Key2 value in order to generate tweak
@@ -603,14 +603,14 @@ typedef struct lac_session_desc_d2_s
     /**< Cipher slice type to be used, set at init session time */
     Cpa8U cipherAesXtsKey1Forward[LAC_CIPHER_AES_XTS_KEY_MAX_LENGTH];
     /**< Cached AES XTS Forward key
-     * For CPM2.0 AES XTS key convertion need to be done in SW.
+     * For CPM2.0 AES XTS key conversion need to be done in SW.
      * Because use can update session direction at any time,
      * also forward key needs to be cached
      */
     Cpa8U cipherAesXtsKey1Reverse[LAC_CIPHER_AES_XTS_KEY_MAX_LENGTH];
     /**< AES XTS Reverse key
-     * For CPM2.0 AES XTS key convertion need to be done in SW.
-     * Reverse key always will be calcilated at session setup time and
+     * For CPM2.0 AES XTS key conversion need to be done in SW.
+     * Reverse key always will be caculated at session setup time and
      * cached to be used when needed */
     Cpa8U cipherAesXtsKey2[LAC_CIPHER_AES_XTS_KEY_MAX_LENGTH];
     /**< For AES XTS session need to store Key2 value in order to generate tweak
@@ -647,7 +647,7 @@ typedef struct lac_session_desc_d2_s
     (sizeof(lac_session_desc_t) + LAC_64BYTE_ALIGNMENT + sizeof(LAC_ARCH_UINT))
 /**< @ingroup LacSym_Session
  * Size of the memory that the client has to allocate for a session. Extra
- * memory is needed to internally re-align the data. The pointer to the algined
+ * memory is needed to internally re-align the data. The pointer to the aligned
  * data is stored at the start of the user allocated memory hence the extra
  * space for an LAC_ARCH_UINT */
 
@@ -691,7 +691,7 @@ typedef struct lac_session_desc_d2_s
 *
 * @param[in] instanceHandle_in    Instance Handle
 * @param[in] pSymCb               callback function
-* @param[in] pSessionSetupData    pointer to the strucutre containing the setup
+* @param[in] pSessionSetupData    pointer to the structure containing the setup
 *data
 * @param[in] isDpSession          CPA_TRUE for a data plane session
 * @param[out] pSessionCtx         Pointer to session context

--- a/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym.h
+++ b/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym.h
@@ -77,7 +77,7 @@
  * The symmetric component demuliplexes the following crypto operations to
  * the appropriate sub-components: cipher, hash, algorithm chaining and
  * authentication encryption. It is a common layer between the above
- * mentioned components where common resources are allocated and paramater
+ * mentioned components where common resources are allocated and parameter 
  * checks are done. The operation specific resource allocation and parameter
  * checks are done in the sub-component itself.
  *
@@ -91,15 +91,15 @@
  *   chain to ensure it is valid.
  * - \ref LacSymStats "Statistics": Manages statistics for symmetric
  * - \ref LacSymQat "Symmetric QAT": The symmetric qat component is
- *   initialiased by the symmetric component.
- * - \ref LacCipher "Cipher" : demultiplex cipher opertions to this component.
- * - \ref LacHash "Hash" : demultiplex hash opertions to this component.
+ *   initialised by the symmetric component.
+ * - \ref LacCipher "Cipher" : demultiplex cipher operations to this component.
+ * - \ref LacHash "Hash" : demultiplex hash operations to this component.
  *   to this component.
  * - \ref LacAlgChain "Algorithm Chaining": The algorithm chaining component
  * - OSAL : Memory allocation, Mutex's, atomics
  *
  * @lld_initialisation
- * This component is initialied during the LAC initialisation sequence. It
+ * This component is initialized during the LAC initialisation sequence. It
  * initialises the session table, statistics, symmetric QAT, initialises the
  * hash definitions lookup table, the hash alg supported lookup table and
  * registers a callback function with the symmetric response handler to process

--- a/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym_alg_chain.h
+++ b/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym_alg_chain.h
@@ -312,17 +312,17 @@ CpaStatus LacAlgChain_Perform(const CpaInstanceHandle instanceHandle,
 * @param[in] pLaCmdFlags                     request service specific flags
 * @param[out] pPrecomputeData                pointer to hash precomputes
 * @param[out] pPrecomputeDataOptimisedCd     pointer to hash setup block of
-*                                            optimised content discriptor
+*                                            optimised content descriptor
 * @param[in] pHwBlockBaseInDRAM              pointer to hash setup block base
 *                                            address in memory
 * @param[out] pHwBlockOffsetInDRAM           pointer to hash setup block offset
-*                                            in the content discriptor
+*                                            in the content descriptor
 * @param[in] pOptimisedHwBlockBaseInDRAM     pointer to hash setup block base
 *                                            address of optimised content
-*                                            discriptor
+*                                            descriptor
 * @param[out] pOptimisedHwBlockOffsetInDRAM  pointer to hash setup block
 *                                            offset in the optimised content
-*                                            discriptor
+*                                            descriptor
 *
 * @retval NONE
 *

--- a/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym_cb.h
+++ b/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym_cb.h
@@ -80,7 +80,7 @@
  *      Dequeue pending requests
  * @description
  *      This function is called by a callback function of a blocking
- *      operation (either a partial packet or a hash precompute operaion)
+ *      operation (either a partial packet or a hash precompute operation)
  *      in softIRQ context. It dequeues requests for the following reasons:
  *          1. All pre-computes that happened when initialising a session
  *             have completed. Dequeue any requests that were queued on the
@@ -99,7 +99,7 @@ CpaStatus LacSymCb_PendingReqsDequeue(lac_session_desc_t *pSessionDesc);
 /**
  *****************************************************************************
  * @ingroup LacSym
- *      Register symmetric callback funcion handlers
+ *      Register symmetric callback function handlers
  *
  * @description
  *      This function registers the symmetric callback handler functions with

--- a/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym_cipher.h
+++ b/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym_cipher.h
@@ -82,14 +82,14 @@
  * and Triple-DES cipher algorithms, in ECB, CBC and CTR modes.  The ARC4 stream
  * cipher algorithm is also supported.  Data may be provided as a full packet,
  * or as a sequence of partial packets.  The result of the operation can be
- * written back to the source buffer (in-place) or to a seperate output buffer
+ * written back to the source buffer (in-place) or to a separate output buffer
  * (out-of-place).  Data must be encapsulated in ICP buffers.
  *
  * The cipher component is responsible for implementing the cipher-specific
  * functionality for registering and de-registering a session, for the perform
  * operation and for processing the QAT responses to cipher requests. Statistics
  * are maintained for cipher in the symmetric \ref CpaCySymStats64 "stats"
- * structure. This module has been seperated out into two. The cipher QAT module
+ * structure. This module has been separated out into two. The cipher QAT module
  * deals entirely with QAT data structures. The cipher module itself has minimal
  * exposure to the QAT data structures.
  *

--- a/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym_hash.h
+++ b/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym_hash.h
@@ -80,7 +80,7 @@
  *
  * The hash component supports hashing in 3 modes. PLAIN, AUTH and NESTED.
  * Plain mode is used to provide data integrity while auth mode is used to
- * provide integrity as well as its authenticity. Nested mode is inteded
+ * provide integrity as well as its authenticity. Nested mode is intended
  * for use by non standard HMAC like algorithms such as for the SSL master
  * key secret. Partial packets is supported for both plain and auth modes.
  * In-place and out-of-place processing is supported for all modes. The
@@ -89,7 +89,7 @@
  * The hash component is responsible for implementing the hash specific
  * functionality for initialising a session and for a perform operation.
  * Statistics are maintained in the symmetric \ref CpaCySymStats64 "stats"
- * structure. This module has been seperated out into two. The hash QAT module
+ * structure. This module has been separated out into two. The hash QAT module
  * deals entirely with QAT data structures. The hash module itself has minimal
  * exposure to the QAT data structures.
  *
@@ -118,7 +118,7 @@
  * the data path by the length of time it takes to do two hashes on a block
  * size of data. Note: a partial packet operation generates an intermediate
  * state. The final operation on a partial packet or when a full packet is
- * used applies padding and gives the final hash result. Esentially for the
+ * used applies padding and gives the final hash result. Essentially for the
  * inner hash, a partial packet final is issued on the data, using the
  * precomputed intermediate state and returns the digest.
  *
@@ -498,7 +498,7 @@ CpaStatus LacHash_PerformParamCheck(CpaInstanceHandle instanceHandle,
 *      This function sends 2 requests to the CPM for the hmac precompute
 *      operations. The results of the ipad and opad state calculation
 *      is copied into pState1 and pState2 (e.g. these may be the state1 and
-*      state2 buffers in a hash content desciptor) and when
+*      state2 buffers in a hash content descriptor) and when
 *      the final operation has completed the condition passed as a param to
 *      this function is set to true.
 *
@@ -581,7 +581,7 @@ CpaStatus LacSymHash_AesECBPreCompute(CpaInstanceHandle instanceHandle,
 *
 * @description
 *      This function registers the precompute callback handler function, which
-*      is different to the default one used by symmetric. Content desciptors
+*      is different to the default one used by symmetric. Content descriptors 
 *      are preallocted for the hmac precomputes as they are constant for these
 *      operations.
 *

--- a/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym_hash_defs.h
+++ b/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym_hash_defs.h
@@ -356,7 +356,7 @@
 /**< @ingroup LacSymQatHash
  * Macro to check for qat hash mode is set to 2 and the hash mode is
  * Auth. This applies to HMAC algorithms (no pre compute). This is used
- * to differntiate between TLS and HMAC */
+ * to differentiate between TLS and HMAC */
 
 #define IS_HASH_MODE_2_NESTED(qatHashMode, hashMode)                           \
     ((IS_HASH_MODE_2(qatHashMode)) && (CPA_CY_SYM_HASH_MODE_NESTED == hashMode))

--- a/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym_hash_precomputes.h
+++ b/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym_hash_precomputes.h
@@ -93,7 +93,7 @@
 /**< maximum size of the working data for the HMAC precompute operations
  *
  * Maximum size of lac_sym_hash_precomp_op_data_t is 264 bytes. For hash
- * precomputes there are 2 of these structrues and a further
+ * precomputes there are 2 of these structures and a further
  * lac_sym_hash_precomp_op_t structure required. This comes to a total of 536
  * bytes.
  * For the asynchronous version of the precomputes, the memory for the hash
@@ -184,7 +184,7 @@ typedef struct lac_sym_hash_aes_precomp_qat_s
     Cpa8U contentDesc[LAC_SYM_QAT_MAX_CIPHER_SETUP_BLK_SZ];
     /**< Content descriptor for a cipher operation */
     Cpa8U data[LAC_SYM_HASH_PRECOMP_MAX_AES_ECB_DATA];
-    /**< The data to be ciphered is conatined here and the result is
+    /**< The data to be ciphered is contained here and the result is
      * written in place back into this buffer */
     icp_qat_fw_la_cipher_req_params_t cipherReqParams;
     /**< Request parameters as read in by the QAT */

--- a/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym_key.h
+++ b/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym_key.h
@@ -72,7 +72,7 @@
  *
  * @lld_overview
  *
- * Key generation component is reponsible for SSL, TLS & MGF operations. All
+ * Key generation component is responsible for SSL, TLS & MGF operations. All
  * memory required for the keygen operations is got from the keygen cookie
  * structure which is carved up as required.
  *
@@ -80,8 +80,8 @@
  * outer hash and SHA1 as the inner hash.
  *
  * Refer to sections in draft-freier-ssl-version3-02.txt:
- *      6.1 Asymmetric cryptographic computations - This refers to coverting
- *          the pre master secret to the master secret.
+ *      6.1 Asymmetric cryptographic computations - This refers to converting
+ *          the pre-master secret to the master secret.
  *      6.2.2 Converting the master secret into keys and MAC secrets - Using
  *          the master secret to generate the key material.
  *
@@ -96,11 +96,11 @@
  *
  * @lld_dependencies
  * \ref LacSymQatHash: for building up hash content descriptor
- * \ref LacMem: for virt to phys coversions
+ * \ref LacMem: for virt to phys conversions
  *
  * @lld_initialisation
- * The reponse handler is registered with Symmetric. The Maximum SSL is
- * allocated. A structure is allocated containing all the TLS lables that
+ * The response handler is registered with Symmetric. The Maximum SSL is
+ * allocated. A structure is allocated containing all the TLS labels that
  * are supported. On shutdown the memory for these structures are freed.
  *
  * @lld_module_algorithms
@@ -157,7 +157,7 @@
  *
  * @description
  *      This structure is used to hold the various TLS labels. Each field is
- *      on an 8 byte boundary provided the structure itslef is 8 bytes aligned.
+ *      on an 8 byte boundary provided the structure itself is 8 bytes aligned.
  *****************************************************************************/
 typedef struct lac_sym_key_tls_labels_s
 {

--- a/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym_partial.h
+++ b/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym_partial.h
@@ -79,7 +79,7 @@
  * proceed where they would get an incorrect digest, cipher result.
  *
  * Maintain a SpinLock for partials in flight per session. Try and acquire this
- * SpinLock. If it cant be acquired return an error straight away to the client
+ * SpinLock. If it can't be acquired return an error straight away to the client
  * as there is already a partial in flight. There is no blocking in the data
  * path for this.
  *

--- a/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym_qat.h
+++ b/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym_qat.h
@@ -83,7 +83,7 @@
  * - \ref LacMem "Memory" - Inline memory functions
  *
  * @lld_initialisation
- * This component is initialied during the LAC initialisation sequence. It
+ * This component is initialized during the LAC initialisation sequence. It
  * is called by the Symmetric Initialisation function.
  *
  * @lld_module_algorithms

--- a/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym_qat_cipher.h
+++ b/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym_qat_cipher.h
@@ -232,7 +232,7 @@ void LacSymQat_CipherXTSModeUpdateKeyLen(lac_session_desc_t *pSessionDesc,
  *      LacSymQat_CipherCtrlBlockInitialize()
  *
  * @description
- *      intialize the cipher control block with all zeros
+ *      initialize the cipher control block with all zeros
  *
  * @param[in]  pMsg                     Pointer to the common request message
  *

--- a/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym_qat_hash.h
+++ b/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym_qat_hash.h
@@ -101,7 +101,7 @@
  *      hash precomputes
  *
  * @description
- *      This structure contains infomation on the hash precomputes
+ *      This structure contains information on the hash precomputes
  *
  *****************************************************************************/
 typedef struct lac_sym_qat_hash_precompute_info_s
@@ -122,7 +122,7 @@ typedef struct lac_sym_qat_hash_precompute_info_s
  *      hash state prefix buffer info
  *
  * @description
- *      This structure contains infomation on the hash state prefix aad buffer
+ *      This structure contains information on the hash state prefix aad buffer
  *
  *****************************************************************************/
 typedef struct lac_sym_qat_hash_state_buffer_info_s

--- a/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym_qat_hash_defs_lookup.h
+++ b/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym_qat_hash_defs_lookup.h
@@ -179,7 +179,7 @@ void LacSymQat_HashAlgLookupGet(CpaInstanceHandle instanceHandle,
 /**
 *******************************************************************************
 * @ingroup LacSymQatHashDefsLookup
-*      get hash defintions from lookup table.
+*      get hash definitions from lookup table.
 *
 * @description
 *      This function looks up the hash lookup array for a structure

--- a/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym_stats.h
+++ b/quickassist/lookaside/access_layer/src/common/crypto/sym/include/lac_sym_stats.h
@@ -68,7 +68,7 @@
  *
  * @ingroup LacSym
  *
- * Symetric Common consists of common statistics, buffer and partial packet
+ * Symmetric Common consists of common statistics, buffer and partial packet
  * functionality.
  *
  ***************************************************************************/
@@ -187,7 +187,7 @@ void LacSym_StatsReset(CpaInstanceHandle instanceHandle);
 /**
 *******************************************************************************
 * @ingroup LacSymStats
-*      Inrement a stat
+*      Increment a stat
 *
 * @description
 *      This function incrementes a stat for a specific engine.

--- a/quickassist/lookaside/access_layer/src/common/crypto/sym/key/lac_sym_key.c
+++ b/quickassist/lookaside/access_layer/src/common/crypto/sym/key/lac_sym_key.c
@@ -2430,9 +2430,9 @@ LacSymKey_CheckParamSslTls(const void *pKeyGenOpData,
         {
             /* Api max value */
             /* ICP_QAT_FW_LA_TLS_V1_1_SECRET_LEN_MAX needs to be multiplied
-             * by 4 in order to verifiy the 512 conditions. We did not change
+             * by 4 in order to verify the 512 conditions. We did not change
              * ICP_QAT_FW_LA_TLS_V1_1_SECRET_LEN_MAX as it represents
-             * the max value tha firmware can handle.
+             * the max value that firmware can handle.
              */
             maxSecretLen = ICP_QAT_FW_LA_TLS_V1_1_SECRET_LEN_MAX * 4;
         }

--- a/quickassist/lookaside/access_layer/src/common/crypto/sym/lac_sym_alg_chain.c
+++ b/quickassist/lookaside/access_layer/src/common/crypto/sym/lac_sym_alg_chain.c
@@ -1701,7 +1701,7 @@ CpaStatus LacAlgChain_SessionInit(
      * create two content descriptors in the case we can support using SHRAM
      * constants and an optimised content descriptor. we have to do this in case
      * of partials.
-     * 64 byte content desciptor is used in the SHRAM case for AES-128-HMAC-SHA1
+     * 64 byte content descriptor is used in the SHRAM case for AES-128-HMAC-SHA1
      *-----------------------------------------------------------------------*/
     if (CPA_STATUS_SUCCESS == status)
     {
@@ -1728,7 +1728,7 @@ CpaStatus LacAlgChain_SessionInit(
                                                &cipherOffsetInConstantsTable,
                                                &hashOffsetInConstantsTable);
 
-        /* for a certain combination of Algorthm Chaining we want to
+        /* for a certain combination of Algorithm Chaining we want to
            use an optimised cd block */
 
         if (pSessionDesc->symOperation == CPA_CY_SYM_OP_ALGORITHM_CHAINING &&

--- a/quickassist/lookaside/access_layer/src/common/crypto/sym/lac_sym_api.c
+++ b/quickassist/lookaside/access_layer/src/common/crypto/sym/lac_sym_api.c
@@ -551,7 +551,7 @@ LacSymPerform_BufferParamCheck(const CpaBufferList *const pSrcBuffer,
         }
     }
 
-    /* check for partial packet suport for the session operation */
+    /* check for partial packet support for the session operation */
     if (CPA_CY_SYM_PACKET_TYPE_FULL != pOpData->packetType)
     {
         if (!(IS_PARTIAL_ON_SYM_OP_SUPPORTED(pSessionDesc->symOperation,
@@ -1068,7 +1068,7 @@ STATIC CpaStatus LacSym_Perform(const CpaInstanceHandle instanceHandle,
 
     if (CPA_STATUS_SUCCESS == status)
     {
-        /* check for partial packet suport for the session operation */
+        /* check for partial packet support for the session operation */
         if (CPA_CY_SYM_PACKET_TYPE_FULL != pOpData->packetType)
         {
             LacSym_PartialPacketStateUpdate(pOpData->packetType,

--- a/quickassist/lookaside/access_layer/src/common/crypto/sym/lac_sym_cb.c
+++ b/quickassist/lookaside/access_layer/src/common/crypto/sym/lac_sym_cb.c
@@ -369,7 +369,7 @@ STATIC void LacSymCb_ProcessDpCallback(CpaCySymDpOpData *pResponse,
     CpaCySymDpCbFunc pSymDpCb = NULL;
 
     /* For CCM and GCM, if qatRespStatusOkFlag is false, the data has to be
-     * cleaned as stated in RFC 3610; in DP mode, it is the user responsability
+     * cleaned as stated in RFC 3610; in DP mode, it is the user responsibility
      * to do so */
 
     if (((CPA_CY_SYM_OP_CIPHER == pSessionDesc->symOperation &&
@@ -531,10 +531,10 @@ CpaStatus LacSymCb_PendingReqsDequeue(lac_session_desc_t *pSessionDesc)
 
         /*
          * Now we'll attempt to send the message directly to QAT. We'll keep
-         * looing until it succeeds (or at least a very high number of retries),
+         * looking until it succeeds (or at least a very high number of retries),
          * as the failure only happens when the ring is full, and this is only
          * a temporary situation. After a few retries, space will become
-         * availble, allowing the putMsg to succeed.
+         * available, allowing the putMsg to succeed.
          */
         retries = 0;
         do

--- a/quickassist/lookaside/access_layer/src/common/crypto/sym/lac_sym_hash_hw_precomputes.c
+++ b/quickassist/lookaside/access_layer/src/common/crypto/sym/lac_sym_hash_hw_precomputes.c
@@ -225,7 +225,7 @@ STATIC void LacSymHash_PrecompCbFunc(icp_qat_fw_la_cmd_id_t lacCmdId,
         }
     }
     /* Check if there are any more pending requests by testing for opsPending
-     * for 0. If there arent then we can signal to the user that we're done
+     * for 0. If there aren't then we can signal to the user that we're done
      */
     if (CPA_FALSE != osalAtomicDecAndTest(&(pOpStatus->opsPending)))
     {
@@ -419,7 +419,7 @@ CpaStatus LacSymHash_HmacPreComputes(CpaInstanceHandle instanceHandle,
      * one after another. As the structure size is a multiple of 8, if the
      * first one is aligned on an 8 byte boundary, so too will the second
      * structure. The pOpStatus structure is carved up just after these two
-     * structures and has no alignment constraints. Pointer arithemtic is
+     * structures and has no alignment constraints. Pointer arithmetic is
      * used to carve the memory up. */
     lac_sym_hash_precomp_op_data_t *pHmacIpadOpData =
         (lac_sym_hash_precomp_op_data_t *)pWorkingMemory;

--- a/quickassist/lookaside/access_layer/src/common/crypto/sym/lac_sym_hash_sw_precomputes.c
+++ b/quickassist/lookaside/access_layer/src/common/crypto/sym/lac_sym_hash_sw_precomputes.c
@@ -112,7 +112,7 @@ CpaStatus LacSymHash_Compute(CpaCySymHashAlgorithm hashAlgorithm,
      * Note: from SHA hashes appropriate endian swapping is required.
      * For sha1, sha224 and sha256 double words based swapping.
      * For sha384 and sha512 quad words swapping.
-     * No endianes swapping for md5 is required.
+     * No endianness swapping for md5 is required.
      */
     CpaStatus status = CPA_STATUS_FAIL;
     Cpa32U i = 0;

--- a/quickassist/lookaside/access_layer/src/common/crypto/sym/lac_sym_queue.c
+++ b/quickassist/lookaside/access_layer/src/common/crypto/sym/lac_sym_queue.c
@@ -164,7 +164,7 @@ CpaStatus LacSymQueue_RequestSend(const CpaInstanceHandle instanceHandle,
          */
         if (CPA_CY_SYM_PACKET_TYPE_FULL != pRequest->pOpData->packetType)
         {
-            /* Select blocking operations which this reqest will complete */
+            /* Select blocking operations which this request will complete */
             pSessionDesc->nonBlockingOpsInProgress = CPA_FALSE;
         }
 

--- a/quickassist/lookaside/access_layer/src/common/crypto/sym/qat/lac_sym_qat_cipher.c
+++ b/quickassist/lookaside/access_layer/src/common/crypto/sym/qat/lac_sym_qat_cipher.c
@@ -488,11 +488,11 @@ static const icp_qat_hw_cipher_info icp_qat_alg_info[] = {
         IS_KEY_DEP_NO,
         NULL,
     },
-    /* RESERVED#1 in order to alinged with unsupported Algo in API repo */
+    /* RESERVED#1 in order to align with unsupported Algo in API repo */
     {0},
-    /* RESERVED#2 in order to alinged with unsupported Algo in API repo */
+    /* RESERVED#2 in order to align with unsupported Algo in API repo */
     {0},
-    /* RESERVED#3 in order to alinged with unsupported Algo in API repo */
+    /* RESERVED#3 in order to align with unsupported Algo in API repo */
     {0},
 };
 
@@ -518,7 +518,7 @@ void LacSymQat_CipherCtrlBlockWrite(icp_qat_la_bulk_req_ftr_t *pMsg,
        in this case, and add padding. It makes no sense
        to force applications to provide such key length for couple reasons:
        1. It won't be possible to distinguish between AES 192 and 256 based
-          on key lenght only
+          on key length only
        2. Only some modes of AES will use UCS slice, then application will
           have to know which ones */
     if (ICP_QAT_FW_LA_USE_UCS_SLICE_TYPE == sliceType &&
@@ -736,7 +736,7 @@ void LacSymQat_CipherHwBlockPopulateKeySetup(
            in this case, and add padding. It makes no sense
            to force applications to provide such key length for couple reasons:
            1. It won't be possible to distinguish between AES 192 and 256 based
-              on key lenght only
+              on key length only
            2. Only some modes of AES will use UCS slice, then application will
               have to know which ones */
         if (ICP_QAT_FW_LA_USE_UCS_SLICE_TYPE == sliceType &&
@@ -1017,7 +1017,7 @@ inline CpaStatus LacSymQat_CipherRequestParamsPopulate(
                 0,
                 totalBufSize - usedBufSize);
         }
-        /* In case of XTS mode using UCS slice always embedd IV.
+        /* In case of XTS mode using UCS slice always encrypt the embedded IV.
          * IV provided by user needs to be encrypted to calculate initial tweak,
          * use pCipherReqParams->u.cipher_IV_array as destination buffer for
          * tweak value */

--- a/quickassist/lookaside/access_layer/src/common/crypto/sym/qat/lac_sym_qat_hash_defs_lookup.c
+++ b/quickassist/lookaside/access_layer/src/common/crypto/sym/qat/lac_sym_qat_hash_defs_lookup.c
@@ -104,7 +104,7 @@ typedef struct lac_sym_qat_hash_def_map_s
     CpaCySymHashAlgorithm hashAlgorithm;
     /* hash algorithm */
     lac_sym_qat_hash_defs_t hashDefs;
-    /* hash defintions pointers */
+    /* hash definitions pointers */
 } lac_sym_qat_hash_def_map_t;
 
 /*
@@ -282,7 +282,7 @@ STATIC lac_sym_qat_hash_alg_info_t sha3_512Info = {
 
 STATIC lac_sym_qat_hash_alg_info_t polyInfo = {LAC_HASH_POLY_DIGEST_SIZE,
                                                LAC_HASH_POLY_BLOCK_SIZE,
-                                               NULL, /* intial state */
+                                               NULL, /* initial state */
                                                LAC_HASH_POLY_STATE_SIZE};
 
 STATIC lac_sym_qat_hash_alg_info_t xcbcMacInfo = {
@@ -299,7 +299,7 @@ STATIC lac_sym_qat_hash_alg_info_t aesCmacInfo = {LAC_HASH_CMAC_128_DIGEST_SIZE,
 STATIC lac_sym_qat_hash_alg_info_t aesCcmInfo = {
     LAC_HASH_AES_CCM_DIGEST_SIZE,
     LAC_HASH_AES_CCM_BLOCK_SIZE,
-    NULL, /* intial state */
+    NULL, /* initial state */
     0     /* state size */
 };
 

--- a/quickassist/lookaside/access_layer/src/common/ctrl/sal_compression.c
+++ b/quickassist/lookaside/access_layer/src/common/ctrl/sal_compression.c
@@ -140,7 +140,7 @@ typedef struct dc_extended_features_s
 } dc_extd_ftrs_t;
 
 /*
- * Prints statistics for a compresion instance
+ * Prints statistics for a compression instance
  */
 STATIC int SalCtrl_CompresionDebug(void *private_data,
                                    char *data,

--- a/quickassist/lookaside/access_layer/src/common/ctrl/sal_crypto.c
+++ b/quickassist/lookaside/access_layer/src/common/ctrl/sal_crypto.c
@@ -1420,7 +1420,7 @@ STATIC int SalCtrl_CryptoDebug(void *private_data,
                 data + len,
                 size - len,
                 BORDER
-                " PRIME successfull requests:     %16llu " BORDER "\n" BORDER
+                " PRIME successful requests:      %16llu " BORDER "\n" BORDER
                 " PRIME failed requests:          %16llu " BORDER "\n" BORDER
                 " PRIME successfully completed:   %16llu " BORDER "\n" BORDER
                 " PRIME failed completion:        %16llu " BORDER "\n" BORDER

--- a/quickassist/lookaside/access_layer/src/common/include/lac_common.h
+++ b/quickassist/lookaside/access_layer/src/common/include/lac_common.h
@@ -256,11 +256,11 @@ char *icpGetProcessName(void);
 
 #define SEPARATOR "+--------------------------------------------------+\n"
 /**< @ingroup LacCommon
- * seperator used for printing stats to standard output*/
+ * separator used for printing stats to standard output*/
 
 #define BORDER "|"
 /**< @ingroup LacCommon
- * seperator used for printing stats to standard output*/
+ * separator used for printing stats to standard output*/
 
 /**
 *****************************************************************************

--- a/quickassist/lookaside/access_layer/src/common/include/lac_hooks.h
+++ b/quickassist/lookaside/access_layer/src/common/include/lac_hooks.h
@@ -69,7 +69,7 @@
  * @ingroup LacCommon
  *
  * Component Init/Shutdown functions. These are:
- *  - an init function which is called during the intialisation sequence,
+ *  - an init function which is called during the initialisation sequence,
  *  - a shutdown function which is called by the overall shutdown function,
  *
  ******************************************************************************/

--- a/quickassist/lookaside/access_layer/src/common/include/lac_mem.h
+++ b/quickassist/lookaside/access_layer/src/common/include/lac_mem.h
@@ -431,7 +431,7 @@ static __inline CpaStatus LacMem_OsContigAlignMemAlloc(void **ppMemAddr,
  *   results in following entry:
  *     static const unsigned int highest_bit_of_lac_mem_blk_t = 3
  *
- *   CAUTION!!
+ *   CAUTION!
  *      Macro is prepared only for type names NOT-containing ANY
  *  special characters. Types as amongst others:
  *  - void *

--- a/quickassist/lookaside/access_layer/src/common/include/lac_mem_pools.h
+++ b/quickassist/lookaside/access_layer/src/common/include/lac_mem_pools.h
@@ -75,19 +75,19 @@
  *     This component is designed as a set of utility functions for the
  * creation of pre-allocated memory pools. Each pool will be created using OS
  * memory with a user specified number of elements, element size and element
- * alignment(alignmnet is at byte granularity).
+ * alignment(alignment is at byte granularity).
  * @lld_dependencies
- *     These utilites rely on OSAL for locking mechanisms and memory allocation
+ *     These utilities rely on OSAL for locking mechanisms and memory allocation
  * @lld_initialisation
  *     Pool creation needs to be done by each component. There is no specific
  * initialisation required for this feature.
  * @lld_module_algorithms
- *     The following is a diagram of how the memory is layed out for each block
+ *     The following is a diagram of how the memory is laid out for each block
  * in a pool. Each element must be aligned on the boundary requested for in the
  * create call.  In order to hide the management of the pools from the user,
  * the memory block data is hidden prior to the
  * data pointer. This way it can be accessed easily on a free call with pointer
- * arithmatic. The Padding at the start is simply there for alignment and is
+ * arithmetic. The Padding at the start is simply there for alignment and is
  * unused in the pools.
  *
  *   -------------------------------------------------------
@@ -209,7 +209,7 @@ typedef struct lac_mem_pool_hdr_s
     (((lac_mem_blk_t *)((LAC_ARCH_UINT)pVirtAddr - sizeof(lac_mem_blk_t)))     \
          ->physDataPtr)
 /**< @ingroup LacMemPool
- *   macro for retreiving the physical address of the memory block. */
+ *   macro for retrieving the physical address of the memory block. */
 
 #define LAC_MEM_POOL_INIT_POOL_ID 0
 /**< @ingroup LacMemPool

--- a/quickassist/lookaside/access_layer/src/common/include/lac_sal.h
+++ b/quickassist/lookaside/access_layer/src/common/include/lac_sal.h
@@ -141,7 +141,7 @@ CpaStatus SalCtrl_ServiceCreate(sal_service_type_t service,
 *                              list: service or qat
 * @param[in]  device           The ADF accelerator handle for the device
 * @param[in]  function         The function pointer to call
-* @param[in/out] status_ret    If an error occured (i.e. status returned from
+* @param[in/out] status_ret    If an error occurred (i.e. status returned from
 *                              function is not _SUCCESS) then status_ret is
 *                              overwritten with status returned from function.
 *
@@ -281,7 +281,7 @@ CpaStatus SalCtrl_CryptoStart(icp_accel_dev_t *device, sal_service_t *service);
  * @ingroup SalCtrl
  * @description
  *      This function is used to stop an instance of crypto service.
- *  It checks for inflight messages to the FW. If no messages are pending
+ *  It checks for in-flight messages to the FW. If no messages are pending
  * it returns success. If messages are pending it returns retry.
  *
  * @context
@@ -381,7 +381,7 @@ CpaStatus SalCtrl_CryptoRestarting(icp_accel_dev_t *device,
 /*************************************************************************
  * @ingroup SalCtrl
  * @description
- *      This function is used to reinitailize an instance of crypto service.
+ *      This function is used to reinitialize an instance of crypto service.
  *  It reinitialzes resources allocated at initialisation - e.g. reinitializes
  *  the memory pools and ADF transport handles.
  *
@@ -486,7 +486,7 @@ CpaStatus SalCtrl_CompressionStart(icp_accel_dev_t *device,
  * @ingroup SalCtrl
  * @description
  *      This function is used to stop an instance of compression service.
- *  It checks for inflight messages to the FW. If no messages are pending
+ *  It checks for in-flight messages to the FW. If no messages are pending
  * it returns success. If messages are pending it returns retry.
  *
  * @context
@@ -568,7 +568,7 @@ CpaStatus SalCtrl_CompressionRestarting(icp_accel_dev_t *device,
 /*************************************************************************
  * @ingroup SalCtrl
  * @description
- *      This function is used to reinitailize an instance of compression
+ *      This function is used to reinitialize an instance of compression
  *  service. It reinitializes resources allocated at initialisation - e.g.
  *  initializes the memory pools and ADF transport handles.
  *
@@ -674,8 +674,8 @@ CpaBoolean SalCtrl_IsServiceSupported(icp_accel_dev_t *device,
 /**
  *******************************************************************************
  * @ingroup LacMemPool
- * This function searchs crypto memory pool of the whole device to find all
- * inflight requests and extract the callback functions from opaque data to
+ * This function searches crypto memory pool of the whole device to find all
+ * in-flight requests and extract the callback functions from opaque data to
  * generate dummy responses.
  *
  * @blocking

--- a/quickassist/lookaside/access_layer/src/common/include/lac_sal_types.h
+++ b/quickassist/lookaside/access_layer/src/common/include/lac_sal_types.h
@@ -262,7 +262,7 @@ typedef struct sal_service_debug_s
  * @param[in] pService         pointer to service instance
  * @param[in] service_type     service type to check againstx.
  *
- * @return CPA_STATUS_FAIL      Paramater is incorrect type
+ * @return CPA_STATUS_FAIL     Parameter is incorrect type
  *
  ******************************************************************************/
 #define SAL_CHECK_INSTANCE_TYPE(pService, service_type)                        \

--- a/quickassist/lookaside/access_layer/src/common/include/lac_sw_responses.h
+++ b/quickassist/lookaside/access_layer/src/common/include/lac_sw_responses.h
@@ -75,7 +75,7 @@
  * @lld_overview
  *     This component is designed as a set of utility functions for the
  * generation of dummy responses and calculation of memory pools which contain
- * inflight requests. If the memory pools contain inflight requests, they
+ * in-flight requests. If the memory pools contain in-flight requests, they
  * will be named as busy memory pools.
  * @lld_dependencies
  *     These utilities rely on OSAL for locking mechanisms and memory
@@ -157,7 +157,7 @@ Cpa16U LacSwResp_GetNumPoolsBusy(void);
 /**
  *******************************************************************************
  * @ingroup LacSwResponses
- * This function searches the pke request memory pool to find all inflight
+ * This function searches the pke request memory pool to find all in-flight
  * requests and extracts the callback function from request data which will be
  * called to generate dummy responses.
  *
@@ -171,7 +171,7 @@ Cpa16U LacSwResp_GetNumPoolsBusy(void);
  *
  *
  * @retval CPA_STATUS_FAIL           The function failed to retrieve all the
- *                                   inflight requests in the memory pool.
+ *                                   in-flight requests in the memory pool.
  * @retval CPA_STATUS_SUCCESS        function executed successfully
  *
  ******************************************************************************/

--- a/quickassist/lookaside/access_layer/src/common/include/sal_qat_cmn_msg.h
+++ b/quickassist/lookaside/access_layer/src/common/include/sal_qat_cmn_msg.h
@@ -209,7 +209,7 @@ void SalQatMsg_CmnMidWrite(icp_qat_fw_la_bulk_req_t *pReq,
  *      icp_qat_fw_comn_req_hdr_cd_pars_t section of the Request Msg.
  *
  * @param[in]   pMsg            Pointer to 128B Request Msg buffer.
- * @param[in]   pContentDescInfo content descripter info.
+ * @param[in]   pContentDescInfo content descriptor info.
  *
  * @return
  *      none

--- a/quickassist/lookaside/access_layer/src/common/include/sal_service_state.h
+++ b/quickassist/lookaside/access_layer/src/common/include/sal_service_state.h
@@ -82,7 +82,7 @@
 *
 * @description
 *      This function checks the state of an instance to see if it is in the
-*      runnning state
+*      running state
 *
 * @param[in]  instance   Instance handle (assumes this is valid, i.e. checked
 *                        before this function is called)

--- a/quickassist/lookaside/access_layer/src/common/qat_comms/sal_qat_cmn_msg.c
+++ b/quickassist/lookaside/access_layer/src/common/qat_comms/sal_qat_cmn_msg.c
@@ -215,7 +215,7 @@ void inline SalQatMsg_CmnMidWrite(icp_qat_fw_la_bulk_req_t *pReq,
  *      icp_qat_fw_comn_req_hdr_cd_pars_t section of the Request Msg.
  *
  * @param[in]   pMsg             Pointer to 128B Request Msg buffer.
- * @param[in]   pContentDescInfo content descripter info.
+ * @param[in]   pContentDescInfo content descriptor info.
  *
  * @return
  *      none

--- a/quickassist/lookaside/access_layer/src/common/utils/lac_buffer_desc.c
+++ b/quickassist/lookaside/access_layer/src/common/utils/lac_buffer_desc.c
@@ -94,7 +94,7 @@
 /* Invalid physical address value */
 #define INVALID_PHYSICAL_ADDRESS 0
 
-/* Indicates what type of buffer writes need to be perfomed */
+/* Indicates what type of buffer writes need to be performed */
 typedef enum lac_buff_write_op_e
 {
     WRITE_NORMAL = 0,
@@ -222,7 +222,7 @@ LacBuffDesc_CommonBufferListDescWrite(const CpaBufferList *pUserBufferList,
 
 /* This function implements the buffer description writes for the traditional
  * APIs Zero length buffers are allowed, should be used for CHA-CHA-POLY and
- * GCM aglorithms */
+ * GCM algorithms */
 CpaStatus LacBuffDesc_BufferListDescWriteAndAllowZeroBuffer(
     const CpaBufferList *pUserBufferList,
     Cpa64U *pBufListAlignedPhyAddr,

--- a/quickassist/lookaside/access_layer/src/common/utils/lac_mem_pools.c
+++ b/quickassist/lookaside/access_layer/src/common/utils/lac_mem_pools.c
@@ -270,7 +270,7 @@ CpaStatus Lac_MemPoolCreate(
     (lac_mem_pools[poolSearch])->blkAlignmentInBytes = blkAlignmentInBytes;
     (lac_mem_pools[poolSearch])->active = CPA_TRUE;
     osalAtomicSet(1, (OsalAtomic *)&((lac_mem_pools[poolSearch])->sync));
-    /* Set the Pool ID output paramter */
+    /* Set the Pool ID output parameter */
     *pPoolID = (LAC_ARCH_UINT)(lac_mem_pools[poolSearch]);
     /* Success */
     return CPA_STATUS_SUCCESS;

--- a/quickassist/lookaside/access_layer/src/common/utils/lac_sw_responses.c
+++ b/quickassist/lookaside/access_layer/src/common/utils/lac_sw_responses.c
@@ -66,8 +66,8 @@
  *
  * @ingroup LacSwResponses
  *
- * Calculation of memory pools which contain infilght requests function
- * implementations. The memory pools which contain inflight requests will
+ * Calculation of memory pools which contain in-flight requests function
+ * implementations. The memory pools which contain in-flight requests will
  * be named as busy memory pools.
  *
  ***************************************************************************/
@@ -190,7 +190,7 @@ lac_memblk_bucket_t *LacSwResp_MemBlkBucketCreate(lac_mem_pool_hdr_t *pPoolID)
 /**
  *******************************************************************************
  * @ingroup LacSwResponses
- * This function frees the bucket with memblks containing inflight requests.
+ * This function frees the bucket with memblks containing in-flight requests.
  ******************************************************************************/
 STATIC
 void LacSwResp_MemBlkBucketDestroy(lac_memblk_bucket_t *pBucket)

--- a/quickassist/lookaside/access_layer/src/qat_direct/common/adf_process_proxy.c
+++ b/quickassist/lookaside/access_layer/src/qat_direct/common/adf_process_proxy.c
@@ -250,7 +250,7 @@ CpaStatus icp_adf_userProxyInit(char const *const name)
     /* Allow the user to call init just once */
     if (init_ctr)
     {
-        ADF_ERROR("User proxy alreay initialized\n");
+        ADF_ERROR("User proxy already initialized\n");
         return status;
     }
     init_ctr = 1;

--- a/quickassist/lookaside/access_layer/src/qat_direct/common/adf_user_device.c
+++ b/quickassist/lookaside/access_layer/src/qat_direct/common/adf_user_device.c
@@ -68,7 +68,7 @@ STATIC adf_event_queue_t adf_event_queue[ADF_MAX_DEVICES] = {{0}};
 STATIC icp_accel_dev_t *accel_tbl[ADF_MAX_DEVICES] = {0};
 
 /*
- * Need to keep track of what device is curently in error
+ * Need to keep track of what device is currently in error
  */
 STATIC char accel_dev_error_stat[ADF_MAX_DEVICES] = {0};
 

--- a/quickassist/lookaside/access_layer/src/qat_direct/common/adf_user_transport_ctrl.c
+++ b/quickassist/lookaside/access_layer/src/qat_direct/common/adf_user_transport_ctrl.c
@@ -205,7 +205,7 @@ STATIC CpaStatus adf_proxy_populate_bank_ring_info(icp_accel_dev_t *accel_dev)
     accel_dev->banks = bankHandler;
     adf_proxy_set_bank_default_info(accel_dev);
 
-    /* allocate ring inflight array ring put/get optimization */
+    /* allocate ring in-flight array ring put/get optimization */
     size = sizeof(*inflight) * (accel_dev->maxNumRingsPerBank >> 1) *
            numOfBanksPerDevice;
     inflight = ICP_MALLOC_GEN(size);
@@ -359,7 +359,7 @@ adf_populate_ring_info_internal(adf_dev_ring_handle_t *pRingHandle,
     }
     else if (ICP_RESP_TYPE_IRQ == resp)
     {
-        /* epoll rings are also polled, so we neeed to set both
+        /* epoll rings are also polled, so we need to set both
          * their polling and interrupt mask
          */
         pRingHandle->pollingMask = 1 << ring_rnum;
@@ -394,7 +394,7 @@ adf_populate_ring_info_internal(adf_dev_ring_handle_t *pRingHandle,
             ((accel_dev->maxNumRingsPerBank * pRingHandle->bank_num) >> 1) +
             (pRingHandle->ring_num - accel_dev->maxNumRingsPerBank / 2);
     }
-    /* Initialise the pRingHandle inflight */
+    /* Initialise the pRingHandle in-flight */
     pRingHandle->in_flight =
         ringInflights[accel_dev->accelId] + in_flight_index;
     *pRingHandle->in_flight = 0;
@@ -827,7 +827,7 @@ STATIC CpaStatus icp_adf_transCleanHandle(icp_comms_trans_handle trans_handle)
     pbanks = accel_dev->banks;
 
     /* update user process IRQ mask
-     * Everytime userspace ring gets a message it reads it from the ring
+     * Every time userspace ring gets a message it reads it from the ring
      * and as the last step needs to enable the IRQ for the ring so
      * the driver could get notifications that there is data on the ring.
      * So this is important to keep the IRQ mask up to date */
@@ -1225,7 +1225,7 @@ CpaStatus icp_sal_pollAllBanks(Cpa32U accelId, Cpa32U response_quota)
  * This will set the fd of the UIO device this instance
  * handler is using. If more than one transaction handler
  * are ever present, this will need to be refactored to
- * return the appropiate fd of the appropiate bank
+ * return the appropriate fd of the appropriate bank
  */
 CpaStatus icp_adf_transGetFdForHandle(icp_comms_trans_handle trans_hnd, int *fd)
 {

--- a/quickassist/lookaside/access_layer/src/qat_direct/common/include/adf_platform_acceldev_4xxx.h
+++ b/quickassist/lookaside/access_layer/src/qat_direct/common/include/adf_platform_acceldev_4xxx.h
@@ -59,7 +59,7 @@
 #define CSR_RING_STAT_RL_EXCEPTION_MASK (0x1UL << 10)
 #define CSR_RING_STAT_RL_HALT_MASK (0x1UL << 9)
 
-/* Ring Base Addresse */
+/* Ring Base Address */
 #define BUILD_RING_BASE_ADDR_4XXX(addr, size)                                  \
     (((addr >> 6) & (0xFFFFFFFFFFFFFFFFULL << size)) << 6)
 

--- a/quickassist/lookaside/access_layer/src/qat_direct/common/include/adf_platform_common.h
+++ b/quickassist/lookaside/access_layer/src/qat_direct/common/include/adf_platform_common.h
@@ -166,7 +166,7 @@
 
 /* Number of responses we need to get before we update the head
  * in a Rx ring. NOTE: this needs to be smaller than
- * min ring size - 8 msg for NF threashold. */
+ * min ring size - 8 msg for NF threshold. */
 #define MIN_RESPONSES_PER_HEAD_WRITE 32
 
 /*
@@ -271,7 +271,7 @@
 #define adf_memcpy128 adf_memcpy32_128
 #endif
 
-/* modulo function that doesnt use slow divide operation */
+/* modulo function that doesn't use slow divide operation */
 static inline unsigned int modulo(unsigned int data, unsigned int shift)
 {
     unsigned int div = data >> shift;
@@ -279,7 +279,7 @@ static inline unsigned int modulo(unsigned int data, unsigned int shift)
     return data - mult;
 }
 
-/* Ring controler CSR Accessor Macros */
+/* Ring controller CSR Accessor Macros */
 /* CSR write macro */
 #define ICP_ADF_CSR_WR(csrAddr, csrOffset, val)                                \
     (void)((*((volatile Cpa32U *)(((Cpa8U *)csrAddr) + csrOffset)) = (val)))

--- a/quickassist/lookaside/access_layer/src/qat_direct/common/include/adf_transport_ctrl.h
+++ b/quickassist/lookaside/access_layer/src/qat_direct/common/include/adf_transport_ctrl.h
@@ -191,7 +191,7 @@ CpaStatus adf_trans_initDynInstancePool(icp_accel_dev_t *accel_dev,
 CpaStatus adf_trans_destroyDynInstancePool(icp_accel_dev_t *accel_dev);
 
 /*
- * Get an availble dynamic instance from the dynamic instance pool
+ * Get an available dynamic instance from the dynamic instance pool
  */
 CpaStatus adf_trans_getDynInstance(icp_accel_dev_t *accel_dev,
                                    adf_service_type_t stype,
@@ -205,7 +205,7 @@ CpaStatus adf_trans_putDynInstance(icp_accel_dev_t *accel_dev,
                                    Cpa32U instance_id);
 
 /*
- * Get the number of the availeble dynamic instances
+ * Get the number of the available dynamic instances
  * in the dynamic instance pool
  */
 CpaStatus adf_trans_getNumAvailDynInstance(icp_accel_dev_t *accel_dev,

--- a/quickassist/lookaside/access_layer/src/qat_direct/vfio/adf_pfvf_vf_msg.h
+++ b/quickassist/lookaside/access_layer/src/qat_direct/vfio/adf_pfvf_vf_msg.h
@@ -89,7 +89,7 @@ int adf_vf2pf_check_compat_version(struct adf_pfvf_dev_data *dev);
  *
  * @param[in] dev	Pointer to VF's pfvf data struct.
  *
- * @retval 0        Function executed succesfully.
+ * @retval 0        Function executed successfully.
  * @retval -EFAULT  Timed out waiting for PF response or received incorrect
  * response
  */
@@ -105,7 +105,7 @@ int adf_vf2pf_get_capabilities(struct adf_pfvf_dev_data *dev);
  *
  * @param[in] dev	Pointer to VF's pfvf data struct.
  *
- * @retval 0        Function executed succesfully.
+ * @retval 0        Function executed successfully.
  * @retval -EFAULT  Timed out waiting for PF response or received incorrect
  * response
  */

--- a/quickassist/lookaside/access_layer/src/qat_direct/vfio/adf_vfio_cfg.c
+++ b/quickassist/lookaside/access_layer/src/qat_direct/vfio/adf_vfio_cfg.c
@@ -454,7 +454,7 @@ CpaStatus adf_io_cfgGetParamValue(icp_accel_dev_t *accel_dev,
     if (ICP_STRNCMP_CONST(pSection, "GENERAL") == 0)
     {
         /*
-         *  All general section paramaters are handled in
+         *  All general section parameters are handled in
          *  QATMGR_MSGTYPE_DEVICE_INFO message
          */
         if (accel_dev->accelId != c_accelId ||

--- a/quickassist/lookaside/access_layer/src/qat_direct/vfio/qat_mgr_lib.c
+++ b/quickassist/lookaside/access_layer/src/qat_direct/vfio/qat_mgr_lib.c
@@ -573,7 +573,7 @@ static int qat_mgr_get_device_capabilities(
     ret = adf_vf2pf_get_capabilities(&vfio_dev.pfvf);
     if (ret)
     {
-        qat_log(LOG_LEVEL_ERROR, "Cannot query device capabilites\n");
+        qat_log(LOG_LEVEL_ERROR, "Cannot query device capabilities\n");
         close_vfio_dev(&vfio_dev);
         device_data->group_fd = -1;
         return ret;
@@ -804,7 +804,7 @@ int qat_mgr_build_data(const struct qatmgr_dev_data dev_list[],
              * qat_mgr_get_device_capabilities will open device, initialize
              * VF2PF communication, query capabilities and close device.
              *
-             * All VFs comming from same PF will have same capabilities, to save
+             * All VFs coming from same PF will have same capabilities, to save
              * time, after querying capabilities of given PF they can be cached
              * and reused by other VFs.
              *

--- a/quickassist/lookaside/access_layer/src/sample_code/README.txt
+++ b/quickassist/lookaside/access_layer/src/sample_code/README.txt
@@ -186,7 +186,7 @@ The number of threads is controlled by the lower of:
     the number of cores
     the number of crypto instance
 
-Based on plaform default value for above parameters are configured in driver configuration file
+Based on platform default value for above parameters are configured in driver configuration file
 
 **IMIX is a mixture of packet sizes 40%-64Byte 20%-752Byte 35% 1504Byte
 5%-8892Byte. of the total submissions
@@ -276,7 +276,7 @@ Example:
 Note: getLatency and getOffloadCost are mutually exclusive i.e. Only one can be
 enabled for a particular invocation of cpa_sample_code application.
 The measurement should be performed with just one active sample code thread.
-i.e.NumberCyInstances and NumberDcInstances shoule be set to 1 in the driver
+i.e.NumberCyInstances and NumberDcInstances should be set to 1 in the driver
 configuration file under SSL section. Also only one device should be active at the
 time of measurement.
 Results may vary depending on platform settings like CPU energy savings, turbo boost, etc.

--- a/quickassist/lookaside/access_layer/src/sample_code/functional/asym/eddsa_sample/cpa_big_num.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/functional/asym/eddsa_sample/cpa_big_num.c
@@ -119,7 +119,7 @@ static void bigNumModAddFunc(BIGNUM *r,
 
 /******************************************************************************
  * @description
- *     This function performs modular substraction operation using OpenSSL
+ *     This function performs modular subtraction operation using OpenSSL
  *     BIGNUM.
  *
  *****************************************************************************/
@@ -196,7 +196,7 @@ CpaStatus bigNum(CpaBigNumOp bigNumOp,
                  CpaFlatBuffer *m_le)
 {
     CpaStatus status = CPA_STATUS_SUCCESS;
-    Cpa8U *r_be = NULL;      /* Pointer to reslut in big endian */
+    Cpa8U *r_be = NULL;      /* Pointer to result in big endian */
     Cpa8U *a_be = NULL;      /* Pointer to input in big endian */
     Cpa8U *b_be = NULL;      /* Pointer to input in big endian */
     Cpa8U *m_be = NULL;      /* Pointer to input in big endian */

--- a/quickassist/lookaside/access_layer/src/sample_code/functional/asym/eddsa_sample/cpa_ed_point_operations.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/functional/asym/eddsa_sample/cpa_ed_point_operations.c
@@ -392,7 +392,7 @@ CpaStatus addPoints(Cpa8U *pPointAx,
     CpaStatus status = CPA_STATUS_FAIL;
     /* Field values buffers */
     CpaFlatBuffer d = {0}, p = {0};
-    /* Input/ Ouptut values buffers */
+    /* Input/ Output values buffers */
     CpaFlatBuffer Ax = {0}, Ay = {0}, Bx = {0}, By = {0}, Cx = {0}, Cy = {0};
     /* Extended point values buffers */
     CpaFlatBuffer X1 = {0}, Y1 = {0}, Z1 = {0}, T1 = {0};

--- a/quickassist/lookaside/access_layer/src/sample_code/functional/include/cpa_sample_utils.h
+++ b/quickassist/lookaside/access_layer/src/sample_code/functional/include/cpa_sample_utils.h
@@ -349,7 +349,7 @@ static __inline CpaStatus Mem_OsMemAlloc(void **ppMemAddr, Cpa32U sizeBytes)
  *
  * @param[out] ppMemAddr    address of pointer where address will be stored
  * @param[in] sizeBytes     the size of the memory to be allocated
- * @param[in] alignement    the alignment of the memory to be allocated
+ * @param[in] alignment    the alignment of the memory to be allocated
  *(non-zero)
  *
  * @retval CPA_STATUS_RESOURCE  Macro failed to allocate Memory
@@ -416,7 +416,7 @@ static __inline CpaStatus Mem_Alloc_Contig(void **ppMemAddr,
 /**
  *******************************************************************************
  * @ingroup sampleUtils
- *     Algined version of PHYS_CONTIG_ALLOC() macro
+ *     Aligned version of PHYS_CONTIG_ALLOC() macro
  *
  ******************************************************************************/
 #define PHYS_CONTIG_ALLOC_ALIGNED(ppMemAddr, sizeBytes, alignment)             \

--- a/quickassist/lookaside/access_layer/src/sample_code/functional/sym/alg_chaining_sample/cpa_algchaining_sample.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/functional/sym/alg_chaining_sample/cpa_algchaining_sample.c
@@ -393,7 +393,7 @@ CpaStatus algChainSample(void)
         /* Perform algchaining operation */
         status = algChainPerformOp(cyInstHandle, sessionCtx);
 
-        /* Wait for inflight requests before removing session */
+        /* Wait for in-flight requests before removing session */
         symSessionWaitForInflightReq(sessionCtx);
 
         /* Remove the session - session init has already succeeded */

--- a/quickassist/lookaside/access_layer/src/sample_code/functional/sym/ccm_sample/cpa_ccm_sample.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/functional/sym/ccm_sample/cpa_ccm_sample.c
@@ -452,7 +452,7 @@ CpaStatus algChainSample(void)
         status =
             algChainPerformOpCCM(cyInstHandle, sessionCtx, GEN_ENCRYPT_DIR);
 
-        /* Wait for inflight requests before removing session */
+        /* Wait for in-flight requests before removing session */
         symSessionWaitForInflightReq(sessionCtx);
 
         /* Remove the session - session init has already succeeded */
@@ -509,7 +509,7 @@ CpaStatus algChainSample(void)
         status =
             algChainPerformOpCCM(cyInstHandle, sessionCtx, DECRYPT_VERIFY_DIR);
 
-        /* Wait for inflight requests before removing session */
+        /* Wait for in-flight requests before removing session */
         symSessionWaitForInflightReq(sessionCtx);
 
         /* Remove the session - session init has already succeeded */

--- a/quickassist/lookaside/access_layer/src/sample_code/functional/sym/cipher_sample/cpa_cipher_sample.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/functional/sym/cipher_sample/cpa_cipher_sample.c
@@ -427,7 +427,7 @@ CpaStatus cipherSample(void)
         /* Perform Cipher operation */
         status = cipherPerformOp(cyInstHandle, sessionCtx);
 
-        /* Wait for inflight requests before removing session */
+        /* Wait for in-flight requests before removing session */
         symSessionWaitForInflightReq(sessionCtx);
 
         /*

--- a/quickassist/lookaside/access_layer/src/sample_code/functional/sym/gcm_sample/cpa_gcm_sample.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/functional/sym/gcm_sample/cpa_gcm_sample.c
@@ -510,7 +510,7 @@ CpaStatus algChainSample(void)
         status = algChainPerformOpGCM(
             cyInstHandle, sessionCtx, GCM_ENCRYPT_DIRECTION);
 
-        /* Wait for inflight requests before removing session */
+        /* Wait for in-flight requests before removing session */
         symSessionWaitForInflightReq(sessionCtx);
 
         /* Remove the session - session init has already succeeded */
@@ -574,7 +574,7 @@ CpaStatus algChainSample(void)
         status = algChainPerformOpGCM(
             cyInstHandle, sessionCtx, GCM_DECRYPT_DIRECTION);
 
-        /* Wait for inflight requests before removing session */
+        /* Wait for in-flight requests before removing session */
         symSessionWaitForInflightReq(sessionCtx);
 
         /* Remove the session - session init has already succeeded */

--- a/quickassist/lookaside/access_layer/src/sample_code/functional/sym/hash_file_sample/cpa_hash_file_sample.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/functional/sym/hash_file_sample/cpa_hash_file_sample.c
@@ -380,7 +380,7 @@ CpaStatus hashFileSample(void)
         /* Perform Hash operation */
         status = hashPerformOp(cyInstHandle, sessionCtx);
 
-        /* Wait for inflight requests before removing session */
+        /* Wait for in-flight requests before removing session */
         symSessionWaitForInflightReq(sessionCtx);
 
         /* Remove the session - session init has already succeeded */

--- a/quickassist/lookaside/access_layer/src/sample_code/functional/sym/hash_sample/cpa_hash_sample.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/functional/sym/hash_sample/cpa_hash_sample.c
@@ -355,7 +355,7 @@ CpaStatus hashSample(void)
         /* Perform Hash operation */
         status = hashPerformOp(cyInstHandle, sessionCtx);
 
-        /* Wait for inflight requests before removing session */
+        /* Wait for in-flight requests before removing session */
         symSessionWaitForInflightReq(sessionCtx);
 
         /* Remove the session - session init has already succeeded */

--- a/quickassist/lookaside/access_layer/src/sample_code/functional/sym/ipsec_sample/cpa_ipsec_sample.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/functional/sym/ipsec_sample/cpa_ipsec_sample.c
@@ -596,7 +596,7 @@ CpaStatus algChainSample(void)
         status =
             algChainPerformOp(cyInstHandle, sessionCtx, IPSEC_OUTBOUND_DIR);
 
-        /* Wait for inflight requests before removing session */
+        /* Wait for in-flight requests before removing session */
         symSessionWaitForInflightReq(sessionCtx);
 
         /* Remove the session - session init has already succeeded */
@@ -657,7 +657,7 @@ CpaStatus algChainSample(void)
         /* Perform algchaining operation */
         status = algChainPerformOp(cyInstHandle, sessionCtx, IPSEC_INBOUND_DIR);
 
-        /* Wait for inflight requests before removing session */
+        /* Wait for in-flight requests before removing session */
         symSessionWaitForInflightReq(sessionCtx);
 
         /* Remove the session - session init has already succeeded */

--- a/quickassist/lookaside/access_layer/src/sample_code/functional/sym/ssl_sample/cpa_ssl_sample.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/functional/sym/ssl_sample/cpa_ssl_sample.c
@@ -534,7 +534,7 @@ CpaStatus algChainSample(void)
         /* Perform algchaining operation */
         status = algChainPerformOp(cyInstHandle, sessionCtx, SSL_OUTBOUND_DIR);
 
-        /* Wait for inflight requests before removing session */
+        /* Wait for in-flight requests before removing session */
         symSessionWaitForInflightReq(sessionCtx);
 
         /* Remove the session - session init has already succeeded */
@@ -592,7 +592,7 @@ CpaStatus algChainSample(void)
         /* Perform algchaining operation */
         status = algChainPerformOp(cyInstHandle, sessionCtx, SSL_INBOUND_DIR);
 
-        /* Wait for inflight requests before removing session */
+        /* Wait for in-flight requests before removing session */
         symSessionWaitForInflightReq(sessionCtx);
 
         /* Remove the session - session init has already succeeded */

--- a/quickassist/lookaside/access_layer/src/sample_code/functional/sym/symdp_sample/cpa_sym_dp_sample.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/functional/sym/symdp_sample/cpa_sym_dp_sample.c
@@ -421,7 +421,7 @@ CpaStatus symDpSample(void)
         /* Remove the session - session init has already succeeded */
         PRINT_DBG("cpaCySymDpRemoveSession\n");
 
-        /* Wait for inflight requests before removing session */
+        /* Wait for in-flight requests before removing session */
         symSessionWaitForInflightReq(sessionCtx);
 
         //<snippet name="removeSession">

--- a/quickassist/lookaside/access_layer/src/sample_code/performance/common/cpa_sample_code_event_manager.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/performance/common/cpa_sample_code_event_manager.c
@@ -513,7 +513,7 @@ void startTimer()
                            VfId);
                     ackCount++;
                 }
-                printf("Total Ack Recived :%d \n", ackCount);
+                printf("Total acks received :%d \n", ackCount);
             }
             //	icp_reset_device((Cpa32U) accelId);
         }

--- a/quickassist/lookaside/access_layer/src/sample_code/performance/compression/cpa_sample_code_dc_dp.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/performance/compression/cpa_sample_code_dc_dp.c
@@ -207,7 +207,7 @@ void dcDpCallbackFunction(CpaDcDpOpData *pOpData)
     if (CPA_DC_WDOG_TIMER_ERR == (Cpa8S)pResults->status)
     {
         PRINT_ERR("Slice hang is detected\n");
-        /* fw does not respond for any furthur requests in case of slice hang
+        /* fw does not respond to any further requests in case of slice hang
          * so, exit the test */
         pPerfData->numOperations = pPerfData->responses;
         pPerfData->threadReturnStatus = CPA_STATUS_FAIL;
@@ -1520,7 +1520,7 @@ static CpaStatus dcDpPerform(compression_test_params_t *setup)
         }
         else
         {
-            /* For performance use cases additonal buffer size  is not required
+            /* For performance use cases additional buffer size  is not required
              * to be added to the cmp buffer, as there is no SW checks*/
             status = createBuffersDp(bufferSize,
                                      setup->numberOfBuffers[i],

--- a/quickassist/lookaside/access_layer/src/sample_code/performance/compression/cpa_sample_code_dc_perf.h
+++ b/quickassist/lookaside/access_layer/src/sample_code/performance/compression/cpa_sample_code_dc_perf.h
@@ -305,7 +305,7 @@ typedef struct compression_test_params_s
     CpaBoolean useE2E;
     CpaDcOpData requestOps;
     /*pointer to function capable of printing our stat related to specific
-     * test varation
+     * test variation
      */
     compute_test_result_func_t passCriteria;
     /* Set this flag to CPA_TRUE to induce overflow and handle it

--- a/quickassist/lookaside/access_layer/src/sample_code/performance/compression/cpa_sample_code_dc_utils.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/performance/compression/cpa_sample_code_dc_utils.c
@@ -1196,7 +1196,7 @@ CpaStatus dcDpPollNumOperationsRetries(perf_data_t *pPerfData,
 }
 
 /* If an error has occurred in-between the submissions loop,
- * wait for all inflight requests has been processed.
+ * wait for all in-flight requests has been processed.
  * Post this function, memory resources that are used by the
  * SAL library are de-allocated.
  */
@@ -1222,7 +1222,7 @@ CpaStatus waitForInflightRequestAfterError(perf_data_t *perfData)
 
     if (perfData->responses < perfData->submissions)
     {
-        PRINT_ERR("WARNING: Not all inflight request collected!! "
+        PRINT_ERR("WARNING: Not all in-flight requests collected! "
                   "Submissions: %u, Responses: %llu\n",
                   perfData->submissions,
                   (unsigned long long)perfData->responses);
@@ -2465,7 +2465,7 @@ CpaStatus sampleRemoveDcDpSession(CpaInstanceHandle dcInstance,
      * by incrementing the sleep time by twice the previous value
      * for each retry. Total sleep time would be 1.6 secs
      * for 15 number of retries which would be enough for all
-     * inflight requests to get processed.
+     * in-flight requests to get processed.
      */
     do
     {

--- a/quickassist/lookaside/access_layer/src/sample_code/performance/compression/qat_compression_main.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/performance/compression/qat_compression_main.c
@@ -241,7 +241,7 @@ static CpaStatus setupDcCommonTest(compression_test_params_t *dcSetup,
         return CPA_STATUS_FAIL;
     }
 
-    /*check that atleast 1 loop of the data set is to be submitted*/
+    /* check that at least 1 loop of the data set is to be submitted*/
     if (numLoops == 0)
     {
         PRINT_ERR("numLoops must be > 0\n");
@@ -572,7 +572,7 @@ void dcPerformance(single_thread_test_data_t *testSetup)
         (testSetup->performanceStats->threadReturnStatus == CPA_STATUS_FAIL))
     {
         // In case of test failure stopDcServicesFromPrintStats function call
-        // from waitForThreadCompletion funtion stops the dc services and not
+        // from waitForThreadCompletion function stops the dc services and not
         // print the performance stats.
         testSetup->statsPrintFunc =
             (stats_print_func_t)stopDcServicesFromPrintStats;
@@ -1319,7 +1319,7 @@ CpaStatus qatCompressData(compression_test_params_t *setup,
             if ((CPA_STATUS_SUCCESS == status) && (instanceInfo2->isPolled))
             {
                 /*
-                 ** Now need to wait for all the inflight Requests.
+                 ** Now need to wait for all the in-flight Requests.
                  */
                 status =
                     dcPollNumOperations(setup->performanceStats,
@@ -1344,7 +1344,7 @@ CpaStatus qatCompressData(compression_test_params_t *setup,
         }
         else
         {
-            /* In case of failure during submissions, all inflight requests
+            /* In case of failure during submissions, all in-flight requests
              * should be collected before releasing memory that is used by
              * the SAL/Driver. This is specially true for async response
              * processing via callback function.
@@ -1553,7 +1553,7 @@ static CpaStatus qatInduceOverflow(compression_test_params_t *setup,
                  * However if some lists don't overflow even after output
                  * buffer reduction, highlight the fact and ignore.
                  */
-                PRINT("!!No Overflow reported for List Num: %d status: %d\n",
+                PRINT("No Overflow reported for List Num: %d status: %d\n",
                       i,
                       resultArray[i].status);
             }

--- a/quickassist/lookaside/access_layer/src/sample_code/performance/compression/qat_compression_main.h
+++ b/quickassist/lookaside/access_layer/src/sample_code/performance/compression/qat_compression_main.h
@@ -515,7 +515,7 @@ void qatDumpBufferListInfo(compression_test_params_t *setup,
  * @ingroup sample_code
  *
  * @description
- *         compare the contents of two bufferlists upto the length of the
+ *         compare the contents of two bufferlists up to the length of the
  *         srcBufferList.
  *
  * @param[in]   ppSrc                   pointer to the source buffer list

--- a/quickassist/lookaside/access_layer/src/sample_code/performance/compression/qat_compression_utils.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/performance/compression/qat_compression_utils.c
@@ -455,7 +455,7 @@ CpaStatus qatAllocateCompressionFlatBuffers(
     }
     else
     {
-        /* For performance use cases additonal buffer size  is not required
+        /* For performance use cases additional buffer size  is not required
          * to be added to the cmp buffer, as there is no SW checks*/
         additionalSize = 0;
     }

--- a/quickassist/lookaside/access_layer/src/sample_code/performance/crypto/cpa_sample_code_crypto_utils.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/performance/crypto/cpa_sample_code_crypto_utils.c
@@ -842,7 +842,7 @@ CpaStatus cyPollNumOperationsTimeout(perf_data_t *pPerfData,
         if (totalCycles > timeout)
         {
             PRINT_ERR("Timeout on polling remaining Operations\n");
-            PRINT("Responses expected = %llu, recieved = %llu\n",
+            PRINT("Responses expected = %llu, received = %llu\n",
                   (unsigned long long)numOperations,
                   (unsigned long long)pPerfData->responses);
             return CPA_STATUS_FAIL;
@@ -1765,7 +1765,7 @@ static void incrementPrimeCandidate(CpaFlatBuffer *primeCandidate)
      * bytes*/
     for (i = primeCandidate->dataLenInBytes - SECOND_LAST_BYTE; i >= 0; i--)
     {
-        /*if the byte is not 0xff then roll over wont occur, and we
+        /*if the byte is not 0xff then roll over won't occur, and we
          * can increment and exit*/
         if (primeCandidate->pData[i] != 0xFF)
         {
@@ -2093,7 +2093,7 @@ CpaStatus generatePrime(CpaFlatBuffer *primeCandidate,
             if ((CPA_STATUS_SUCCESS == status) && (isPolled))
             {
                 /*
-                ** Now need to wait for all the inflight Requests.
+                ** Now need to wait for all the in-flight Requests.
                 */
                 status = cyPollNumOperationsTimeout(&primePerfData,
                                                     setup->cyInstanceHandle,
@@ -2583,7 +2583,7 @@ CpaStatus calcDigest(CpaInstanceHandle instanceHandle,
         if ((CPA_STATUS_SUCCESS == status) && (isPolled))
         {
             /*
-            ** Now need to wait for all the inflight Requests.
+            ** Now need to wait for all the in-flight Requests.
             */
             status = cyPollNumOperations(
                 pPerfData, instanceHandle, pPerfData->numOperations);
@@ -2623,7 +2623,7 @@ CpaStatus removeSymSession(CpaInstanceHandle instanceHandle,
          * by incrementing the sleep time by twice the previous value
          * for each retry. Total sleep time would be 1.6 secs
          * for 15 number of retries which would be enough for all
-         * inflight requests to get processed.
+         * in-flight requests to get processed.
          */
         Cpa64U delay = REMOVE_SESSION_WAIT;
         static const Cpa16U maxRetries = 15;
@@ -2667,9 +2667,9 @@ CpaStatus removeSymSession(CpaInstanceHandle instanceHandle,
     do
     {
         /* Linux: The session will only be removed if there are
-         * no inflight requests. Until then, the function will
+         * no in-flight requests. Until then, the function will
          * ask to retry. This should not result in infinite loop
-         * as all inflight requests are guranteed to return even
+         * as all in-flight requests are guaranteed to return even
          * in case of QAT failure or hang.
          * */
         status = cpaCySymRemoveSession(instanceHandle, pSessionCtx);
@@ -2754,7 +2754,7 @@ void processCallback(void *pCallbackTag)
     /*check tag exists*/
     if (pCallbackTag == NULL)
     {
-        PRINT_ERR("CallBack Tag is a Null pointer!!\n");
+        PRINT_ERR("CallBack Tag is a Null pointer!\n");
         return;
     }
     /* response has been received */
@@ -4046,7 +4046,7 @@ CpaStatus checkForChachapolySupport(void)
     }
     if (0 == numCyInstances)
     {
-        PRINT_ERR("There are no Crypto Instances avaialble!\n");
+        PRINT_ERR("There are no Crypto Instances available!\n");
         return CPA_STATUS_FAIL;
     }
     cyInstances = qaeMemAlloc(sizeof(CpaInstanceHandle) * numCyInstances);

--- a/quickassist/lookaside/access_layer/src/sample_code/performance/crypto/cpa_sample_code_crypto_utils.h
+++ b/quickassist/lookaside/access_layer/src/sample_code/performance/crypto/cpa_sample_code_crypto_utils.h
@@ -755,7 +755,7 @@ typedef struct symmetric_test_params_s
     Cpa64U initialVerifyFailures;
     Cpa32U submissions;
     Cpa32U node;
-    /**< Variable to triger generating of random numbers for nested has inside
+    /**< Variable to trigger generating of random numbers for nested has inside
      * of setup function to avoid mismatch caused by using shared buffers
      * between threads.
      */
@@ -1320,7 +1320,7 @@ CpaStatus setupKeyGenHkdfTest(sync_mode_t syncMode,
                               Cpa32U numBuffers,
                               Cpa32U numLoops);
 /* The API version check does not guarantee if EC Mont Edwards is
- * suported by the driver. This function checks by making an API
+ * supported by the driver. This function checks by making an API
  * call to see if the status reports CPA_STATUS_UNSUPPORTED.
  */
 CpaBoolean isECMontEdwdsSupported(void);
@@ -1343,7 +1343,7 @@ CpaStatus setupEcMontEdwdsTest(sync_mode_t syncMode,
 
 #if CY_API_VERSION_AT_LEAST(3, 0)
 /* The API version check does not guarantee if EC Generic Curves are
- * suported by the driver. This function checks by making an API
+ * supported by the driver. This function checks by making an API
  * call to see if the status reports CPA_STATUS_UNSUPPORTED.
  */
 CpaBoolean isECGenericCurveSupported(void);

--- a/quickassist/lookaside/access_layer/src/sample_code/performance/crypto/cpa_sample_code_dh_perf.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/performance/crypto/cpa_sample_code_dh_perf.c
@@ -448,7 +448,7 @@ CpaStatus dhPhase1(CpaCyDhPhase1KeyGenOpData **pCpaDhOpDataP1,
         if ((CPA_STATUS_SUCCESS == status) && (instanceInfo->isPolled))
         {
             /*
-            ** Now need to wait for all the inflight Requests.
+            ** Now need to wait for all the in-flight Requests.
             */
             status = cyPollNumOperations(
                 pPerfData, setup->cyInstanceHandle, pPerfData->numOperations);
@@ -759,7 +759,7 @@ CpaStatus dhPhase2Perform(CpaFlatBuffer **pOctetStringSecretKey,
         if ((CPA_STATUS_SUCCESS == status) && (instanceInfo->isPolled))
         {
             /*
-            ** Now need to wait for all the inflight Requests.
+            ** Now need to wait for all the in-flight Requests.
             */
             status = cyPollNumOperations(
                 pPerfData, setup->cyInstanceHandle, pPerfData->numOperations);

--- a/quickassist/lookaside/access_layer/src/sample_code/performance/crypto/cpa_sample_code_dsa_perf.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/performance/crypto/cpa_sample_code_dsa_perf.c
@@ -439,7 +439,7 @@ CpaStatus dsaGenG(CpaInstanceHandle instanceHandle,
         if ((CPA_STATUS_SUCCESS == status) && (instanceInfo2.isPolled))
         {
             /*
-            ** Now need to wait for all the inflight Requests.
+            ** Now need to wait for all the in-flight Requests.
             */
             status = cyPollNumOperations(
                 pPerfData, instanceHandle, pPerfData->numOperations);
@@ -534,7 +534,7 @@ CpaStatus dsaGenY(CpaInstanceHandle instanceHandle,
         if ((CPA_STATUS_SUCCESS == status) && (instanceInfo2.isPolled))
         {
             /*
-            ** Now need to wait for all the inflight Requests.
+            ** Now need to wait for all the in-flight Requests.
             */
             status = cyPollNumOperations(
                 pPerfData, instanceHandle, pPerfData->numOperations);
@@ -636,7 +636,7 @@ CpaStatus dsaGenRS(CpaInstanceHandle instanceHandle,
         if ((CPA_STATUS_SUCCESS == status) && (instanceInfo2.isPolled))
         {
             /*
-            ** Now need to wait for all the inflight Requests.
+            ** Now need to wait for all the in-flight Requests.
             */
             status = cyPollNumOperations(
                 pPerfData, instanceHandle, pPerfData->numOperations);
@@ -1250,7 +1250,7 @@ barrier:
         if ((CPA_STATUS_SUCCESS == status) && (instanceInfo2->isPolled))
         {
             /*
-            ** Now need to wait for all the inflight Requests.
+            ** Now need to wait for all the in-flight Requests.
             */
             status = cyPollNumOperations(
                 pPerfData, setup->cyInstanceHandle, pPerfData->numOperations);
@@ -1693,7 +1693,7 @@ barrier:
         if ((CPA_STATUS_SUCCESS == status) && (instanceInfo2->isPolled))
         {
             /*
-            ** Now need to wait for all the inflight Requests.
+            ** Now need to wait for all the in-flight Requests.
             */
             status = cyPollNumOperations(
                 pPerfData, setup->cyInstanceHandle, pPerfData->numOperations);
@@ -1735,7 +1735,7 @@ barrier:
  *      dsaPrintStats
  *
  * @description
- *     Print out the DSA perfomance
+ *     Print out the DSA performance
  *
  *****************************************************************************/
 CpaStatus dsaPrintStats(thread_creation_data_t *data)

--- a/quickassist/lookaside/access_layer/src/sample_code/performance/crypto/cpa_sample_code_ec_montedwds_perf.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/performance/crypto/cpa_sample_code_ec_montedwds_perf.c
@@ -501,7 +501,7 @@ static CpaStatus ecMontEdwdsPerform(ec_montedwds_test_params_t *setup)
     pPerfData->numOperations = (Cpa64U)setup->numBuffers * setup->numLoops;
     coo_init(pPerfData, pPerfData->numOperations);
 
-    /* Initilise semaphore used in callback */
+    /* Initialise semaphore used in callback */
     sampleCodeSemaphoreInit(&pPerfData->comp, 0);
 
     /* set the callback function if asynchronous mode is set */
@@ -645,7 +645,7 @@ static CpaStatus ecMontEdwdsPerform(ec_montedwds_test_params_t *setup)
         {
             if ((instanceInfo2->isPolled))
             {
-                /* Now need to wait for all the inflight Requests */
+                /* Now need to wait for all the in-flight Requests */
                 pollStatus = cyPollNumOperations(pPerfData,
                                                  setup->cyInstanceHandle,
                                                  pPerfData->numOperations);

--- a/quickassist/lookaside/access_layer/src/sample_code/performance/crypto/cpa_sample_code_ecdsa_perf.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/performance/crypto/cpa_sample_code_ecdsa_perf.c
@@ -399,7 +399,7 @@ CpaStatus calcEcPoint(ecdsa_test_params_t *setup,
         if ((CPA_STATUS_SUCCESS == status) && (instanceInfo2->isPolled))
         {
             /*
-            ** Now need to wait for all the inflight Requests.
+            ** Now need to wait for all the in-flight Requests.
             */
             status = cyPollNumOperations(
                 pPerfData, setup->cyInstanceHandle, pPerfData->numOperations);
@@ -837,7 +837,7 @@ CpaStatus ecdsaSignRS(ecdsa_test_params_t *setup,
         if ((CPA_STATUS_SUCCESS == status) && (isPolled))
         {
             /*
-            ** Now need to wait for all the inflight Requests.
+            ** Now need to wait for all the in-flight Requests.
             */
             status = cyPollNumOperations(
                 pPerfData, setup->cyInstanceHandle, pPerfData->numOperations);
@@ -1358,7 +1358,7 @@ CpaStatus ecdsaPerform(ecdsa_test_params_t *setup)
     status = calcEcPoint(setup, &privateKey, pX, pY);
     if (CPA_STATUS_SUCCESS != status)
     {
-        PRINT_ERR("calcEcPoint Failes with status %d\n", status);
+        PRINT_ERR("calcEcPoint fails with status %d\n", status);
         ECDSA_PERFORM_MEM_FREE();
         goto barrier;
     }
@@ -1626,7 +1626,7 @@ barrier:
         if ((instanceInfo->isPolled))
         {
             /*
-            ** Now need to wait for all the inflight Requests.
+            ** Now need to wait for all the in-flight Requests.
             */
             status = cyPollNumOperations(
                 pEcdsaData, setup->cyInstanceHandle, pEcdsaData->numOperations);

--- a/quickassist/lookaside/access_layer/src/sample_code/performance/crypto/cpa_sample_code_ike_rsa_perf.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/performance/crypto/cpa_sample_code_ike_rsa_perf.c
@@ -633,7 +633,7 @@ static CpaStatus ikeRsaPerform(asym_test_params_t *setup)
 
     if (CPA_STATUS_SUCCESS != status)
     {
-        PRINT_ERR("Error, failed to allcate ppPVverifier2, status: %d\n",
+        PRINT_ERR("Error, failed to allocate ppPVverifier2, status: %d\n",
                   status);
         ikeRsaMemFree(setup, &alice, &bob, pPrivateKey, pPublicKey);
         return status;

--- a/quickassist/lookaside/access_layer/src/sample_code/performance/crypto/cpa_sample_code_rsa_perf.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/performance/crypto/cpa_sample_code_rsa_perf.c
@@ -511,7 +511,7 @@ CpaStatus generateRSAKey(CpaInstanceHandle instanceHandle,
         if ((CPA_STATUS_SUCCESS == status) && (instanceInfo2->isPolled))
         {
             /*
-            ** Now need to wait for all the inflight Requests.
+            ** Now need to wait for all the in-flight Requests.
             */
             status = cyPollNumOperations(
                 pPerfData, setup->cyInstanceHandle, pPerfData->numOperations);
@@ -982,7 +982,7 @@ EXPORT_SYMBOL(rsaFreeDataMemory);
  * @description
  * This function frees all memory related to RSA key data. This function must be
  * called before rsaFreeDataMemory otherwise the pointers to the key data will
- * be lost and we wont be able to free the memory
+ * be lost and we won't be able to free the memory
  * ****************************************************************************/
 void rsaFreeKeyMemory(asym_test_params_t *setup,
                       CpaCyRsaPrivateKey *pPrivateKey[],
@@ -1626,7 +1626,7 @@ CpaStatus sampleRsaDecrypt(asym_test_params_t *setup,
         if ((CPA_STATUS_SUCCESS == status) && (isPolled))
         {
             /*
-            ** Now need to wait for all the inflight Requests.
+            ** Now need to wait for all the in-flight Requests.
             */
             status = cyPollNumOperations(
                 pPerfData, setup->cyInstanceHandle, pPerfData->numOperations);

--- a/quickassist/lookaside/access_layer/src/sample_code/performance/crypto/cpa_sample_code_sym_perf.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/performance/crypto/cpa_sample_code_sym_perf.c
@@ -855,7 +855,7 @@ CpaStatus symPerform(symmetric_test_params_t *setup,
         if ((CPA_STATUS_SUCCESS == status) && (instanceInfo2->isPolled))
         {
             /*
-            ** Now need to wait for all the inflight Requests.
+            ** Now need to wait for all the in-flight Requests.
             */
             status = cyPollNumOperations(
                 pSymData, setup->cyInstanceHandle, pSymData->numOperations);

--- a/quickassist/lookaside/access_layer/src/sample_code/performance/crypto/cpa_sample_code_sym_perf_dp.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/performance/crypto/cpa_sample_code_sym_perf_dp.c
@@ -1410,7 +1410,7 @@ CpaStatus symDpPerformEnqueueOp(symmetric_test_params_t *setup,
     if (CPA_STATUS_SUCCESS == status)
     {
         /*
-        ** Now need to wait for all the inflight Requests.
+        ** Now need to wait for all the in-flight Requests.
         */
         status = cyDpPollNumOperations(
             pSymData, setup->cyInstanceHandle, pSymData->numOperations);
@@ -1705,7 +1705,7 @@ CpaStatus symDpPerformEnqueueOpBatch(symmetric_test_params_t *setup,
     if (CPA_STATUS_SUCCESS == status)
     {
         /*
-        ** Now need to wait for all the inflight Requests.
+        ** Now need to wait for all the in-flight Requests.
         */
         status = cyDpPollNumOperations(
             pSymData, setup->cyInstanceHandle, pSymData->numOperations);

--- a/quickassist/lookaside/access_layer/src/sample_code/performance/crypto/cpa_sample_code_sym_update.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/performance/crypto/cpa_sample_code_sym_update.c
@@ -292,7 +292,7 @@ static CpaStatus updatePerformCipher(symmetric_test_params_t *setup,
     return status;
 }
 
-// Perfom for hash session
+// Perform for hash session
 static CpaStatus updatePerformHash(symmetric_test_params_t *setup,
                                    CpaCySymSessionCtx sessionCtx,
                                    CpaCySymSessionUpdateData *pSessionUpdate,
@@ -365,7 +365,7 @@ static CpaStatus updatePerformHash(symmetric_test_params_t *setup,
         }
         else
         {
-            PRINT_ERR("Update sesssion failed\n");
+            PRINT_ERR("Update session failed\n");
             status = CPA_STATUS_FAIL;
         }
     }

--- a/quickassist/lookaside/access_layer/src/sample_code/performance/crypto/cpa_sample_code_sym_update_dp.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/performance/crypto/cpa_sample_code_sym_update_dp.c
@@ -336,7 +336,7 @@ static CpaStatus updatePerformCipherDp(
     return status;
 }
 
-// Perfom for hash session
+// Perform for hash session
 static CpaStatus updatePerformHashDp(symmetric_test_params_t *setup,
                                      CpaCySymSessionCtx sessionCtx,
                                      CpaCySymSessionUpdateData *pSessionUpdate,

--- a/quickassist/lookaside/access_layer/src/sample_code/performance/crypto/qat_sym_utils.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/performance/crypto/qat_sym_utils.c
@@ -841,7 +841,7 @@ CpaStatus qatSymPerform(symmetric_test_params_t *setup,
         if ((CPA_STATUS_SUCCESS == status) && (instanceInfo2.isPolled))
         {
             /*
-            ** Now need to wait for all the inflight Requests.
+            ** Now need to wait for all the in-flight Requests.
             */
             status = cyPollNumOperations(
                 pSymData, setup->cyInstanceHandle, pSymData->numOperations);

--- a/quickassist/lookaside/access_layer/src/sample_code/performance/framework/cpa_sample_code_framework.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/performance/framework/cpa_sample_code_framework.c
@@ -185,7 +185,7 @@ Cpa32U coreLimit_g = 0;
  * before all threads are created*/
 /*this is a shared mutex between user space threads, if one thread locks this
  * all other threads wait until its released, which is done by calling the
- * cpa_sample_code_mutex_unlock ot cpa_sample_code_barrier_wait function*/
+ * cpa_sample_code_mutex_unlock or cpa_sample_code_barrier_wait function*/
 sample_code_thread_mutex_t threadControlMutex_g;
 
 /*this is the conditional variable that user space threads wait on to start, the
@@ -689,7 +689,7 @@ CpaStatus startThreads(void)
     {
         if (sampleCodeThreadStart(&threads_g[threadId]) != CPA_STATUS_SUCCESS)
         {
-            /* if we cant start one thread we kill all created threads
+            /* if we can't start one thread we kill all created threads
              * and return fail*/
             for (threadId = 0; threadId < numCreatedThreads_g; threadId++)
             {
@@ -706,7 +706,7 @@ CpaStatus startThreads(void)
                     qaeMemFree((void **)&perfStats_g[i]);
                 }
             }
-            PRINT_ERR("cant start threads\n");
+            PRINT_ERR("can't start threads\n");
             return CPA_STATUS_FAIL;
         }
     }
@@ -1105,7 +1105,7 @@ CpaStatus createPerfomanceThreads(Cpa32U numLogicalIaCoresToUse,
  * threadoffset : The thread number to start with reprocessing.
  * cyIaCore     : The Crypto Instances array that includes both sym
  *                and asym instances.
- * symOrasymIaCore : The Symmetric or Asymetric Crypto array.
+ * symOrasymIaCore : The Symmetric or Asymmetric Crypto array.
  * numCyInstances : size of cyIaCore array.
  */
 void qatModifyCyThreadLogicalQaInstance(Cpa8U threadOffset,

--- a/quickassist/lookaside/access_layer/src/sample_code/performance/framework/cpa_sample_code_framework.h
+++ b/quickassist/lookaside/access_layer/src/sample_code/performance/framework/cpa_sample_code_framework.h
@@ -172,7 +172,7 @@ typedef struct thread_creation_data_s
     /*flat buffer size to be tested*/
     stats_print_func_t *statsPrintFunc;
     /*pointer to function capable of printing our stat related to specific
-     * test varation*/
+     * test variation*/
     Cpa32U megaRowId;
     /* mega row id reference */
     CpaBoolean isUsedByMega;
@@ -570,7 +570,7 @@ CpaStatus createPerfomanceThreads(Cpa32U numLogicalIaCoresToUse,
  * @param[in]   cyIaCore     : The Crypto Instances array that includes both sym
  *                             and asym instances.
  *
- * @param[in]   symOrasymIaCore : The Symmetric or Asymetric Crypto array.
+ * @param[in]   symOrasymIaCore : The Symmetric or Asymmetric Crypto array.
  *                             and asym instances.
  * @param[in]   numCyInstances  : size of cyIaCore array.
  *

--- a/quickassist/lookaside/access_layer/src/sample_code/performance/framework/cpa_sample_code_utils_common.h
+++ b/quickassist/lookaside/access_layer/src/sample_code/performance/framework/cpa_sample_code_utils_common.h
@@ -878,7 +878,7 @@ CpaStatus sampleCodeTimeTGet(sample_code_time_t *pTime);
  *      sampleCodeSemaphoreInit
  *
  * @description
- *      initilises a semaphore type with start value
+ *      initialises a semaphore type with start value
  *
  *
  * @param[out] *semPtr, is the semaphore to be initialized

--- a/quickassist/lookaside/access_layer/src/sample_code/performance/framework/linux/user_space/cpa_sample_code_utils.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/performance/framework/linux/user_space/cpa_sample_code_utils.c
@@ -658,7 +658,7 @@ CpaStatus sampleCodeSemaphoreInit(sample_code_semaphore_t *semPtr,
 {
     CHECK_POINTER_AND_RETURN_FAIL_IF_NULL(semPtr);
     /*
-     *  Allocate memory for the sempahore object.
+     *  Allocate memory for the semaphore object.
      */
     *semPtr = qaeMemAlloc(sizeof(sem_t));
     if (!(*semPtr))

--- a/quickassist/lookaside/access_layer/src/sample_code/performance/framework/linux/user_space/cpa_sample_code_utils.h
+++ b/quickassist/lookaside/access_layer/src/sample_code/performance/framework/linux/user_space/cpa_sample_code_utils.h
@@ -152,7 +152,7 @@ extern int parseArg(int argc, char **argv, option_t *optArray, int numOpt);
         int ret = (fn);                                                        \
         if (ret != 0)                                                          \
         {                                                                      \
-            PRINT_ERR("pthread function failed with errro:%d\n", ret);         \
+            PRINT_ERR("pthread function failed with error:%d\n", ret);         \
         }                                                                      \
     } while (0)
 

--- a/quickassist/lookaside/access_layer/src/sample_code/performance/qae/linux/kernel_space/qae_mem_utils.c
+++ b/quickassist/lookaside/access_layer/src/sample_code/performance/qae/linux/kernel_space/qae_mem_utils.c
@@ -179,7 +179,7 @@ void qaeMemFreeNUMA(void **ptr)
 
     if (memInfo->mSize == 0 || memInfo->mAllocMemPtr == NULL)
     {
-        printk("Detected the corrupted data: memory leak!! \n");
+        printk("Detected the corrupted data: memory leak!\n");
         printk("Size: %d, memPtr: %p\n", memInfo->mSize, memInfo->mAllocMemPtr);
         return;
     }

--- a/quickassist/lookaside/firmware/include/icp_qat_fw.h
+++ b/quickassist/lookaside/firmware/include/icp_qat_fw.h
@@ -297,11 +297,11 @@ typedef struct icp_qat_fw_comn_req_mid_s
      * field */
 
     uint32_t src_length;
-    /** < Length of source flat buffer incase src buffer
+    /** < Length of source flat buffer in case src buffer
      * type is flat */
 
     uint32_t dst_length;
-    /** < Length of source flat buffer incase dst buffer
+    /** < Length of source flat buffer in case dst buffer
      * type is flat */
 
 } icp_qat_fw_comn_req_mid_t;

--- a/quickassist/lookaside/firmware/include/icp_qat_fw_dc_chain.h
+++ b/quickassist/lookaside/firmware/include/icp_qat_fw_dc_chain.h
@@ -134,7 +134,7 @@ typedef enum
  * @ingroup icp_qat_fw_dc_chain
  *
  * @description
- *     Define the chaining request discriptor header
+ *     Define the chaining request descriptor header
  *
  *****************************************************************************/
 typedef struct icp_qat_comp_chain_req_hdr_s

--- a/quickassist/lookaside/firmware/include/icp_qat_fw_la.h
+++ b/quickassist/lookaside/firmware/include/icp_qat_fw_la.h
@@ -504,7 +504,7 @@ typedef struct icp_qat_fw_la_bulk_req_s
  * the case of partial processing. See the HLD for further details
  *
  *  + ====== + ------------------------- + ----------------------- +
- *  | Parial |       Prefix Addr         |       Hash State Sz     |
+ *  | Partial|       Prefix Addr         |       Hash State Sz     |
  *  | State  |                           |                         |
  *  + ====== + ------------------------- + ----------------------- +
  *  |  FULL  | Points to the prefix data | Prefix size as below.   |
@@ -562,7 +562,7 @@ typedef struct icp_qat_fw_la_bulk_req_s
  *                         is required
  * @param ciphIV           Cipher IV field contents
  * @param ciphcfg          Cipher/Auth Config offset type
- * @param partial          Inidicate if the packet is a partial part
+ * @param partial          Indicate if the packet is a partial part
  *
  *****************************************************************************/
 #define ICP_QAT_FW_LA_FLAGS_BUILD(zuc_proto,                                   \
@@ -1079,7 +1079,7 @@ typedef struct icp_qat_fw_cipher_cd_ctrl_hdr_s
     /**< LW 27 */
     uint8_t cipher_state_sz;
     /**< State size in quad words of the cipher algorithm used in this session.
-     * Set to zero if the algorithm doesnt provide any state */
+     * Set to zero if the algorithm doesn't provide any state */
 
     uint8_t cipher_key_sz;
     /**< Key size in quad words of the cipher algorithm used in this session */
@@ -1213,7 +1213,7 @@ typedef struct icp_qat_fw_cipher_auth_cd_ctrl_hdr_s
     /**< LW 27 */
     uint8_t cipher_state_sz;
     /**< State size in quad words of the cipher algorithm used in this session.
-     * Set to zero if the algorithm doesnt provide any state */
+     * Set to zero if the algorithm doesn't provide any state */
 
     uint8_t cipher_key_sz;
     /**< Key size in quad words of the cipher algorithm used in this session */

--- a/quickassist/lookaside/firmware/include/icp_qat_fw_mmp.h
+++ b/quickassist/lookaside/firmware/include/icp_qat_fw_mmp.h
@@ -68,7 +68,7 @@
  * @brief
  *      This file documents the external interfaces that the QAT FW running
  *      on the QAT Acceleration Engine provides to clients wanting to
- *      accelerate crypto assymetric applications
+ *      accelerate crypto asymmetric applications
  */
 
 #ifndef __ICP_QAT_FW_MMP__
@@ -87,10 +87,10 @@
  */
 #define ICP_QAT_FW_PKE_INPUT_COUNT_MAX 7
 /**< @ingroup icp_qat_fw_pke
- * Maximum number of input paramaters in all PKE request */
+ * Maximum number of input parameters in all PKE request */
 #define ICP_QAT_FW_PKE_OUTPUT_COUNT_MAX 5
 /**< @ingroup icp_qat_fw_pke
- * Maximum number of output paramaters in all PKE request */
+ * Maximum number of output parameters in all PKE request */
 
 /**
  * @ingroup icp_qat_fw_mmp

--- a/quickassist/lookaside/firmware/include/icp_qat_fw_mmp_ids.h
+++ b/quickassist/lookaside/firmware/include/icp_qat_fw_mmp_ids.h
@@ -68,7 +68,7 @@
  * @brief
  *      This file documents the external interfaces that the QAT FW running
  *      on the QAT Acceleration Engine provides to clients wanting to
- *      accelerate crypto assymetric applications
+ *      accelerate crypto asymmetric applications
  */
 
 #ifndef __ICP_QAT_FW_MMP_IDS__

--- a/quickassist/lookaside/firmware/include/icp_qat_fw_pke.h
+++ b/quickassist/lookaside/firmware/include/icp_qat_fw_pke.h
@@ -66,7 +66,7 @@
  * @brief
  *      This file documents the external interfaces that the QAT FW running
  *      on the QAT Acceleration Engine provides to clients wanting to
- *      accelerate crypto assymetric applications
+ *      accelerate crypto asymmetric applications
  */
 
 #ifndef _ICP_QAT_FW_PKE_

--- a/quickassist/lookaside/firmware/include/icp_qat_hw.h
+++ b/quickassist/lookaside/firmware/include/icp_qat_hw.h
@@ -224,7 +224,7 @@ typedef struct icp_qat_hw_auth_config_s
 
 #define QAT_AUTH_MODE_MASK 0xF
 /**< @ingroup icp_qat_hw_defs
- * Four bit mask used for determing the Auth mode */
+ * Four bit mask used for determining the Auth mode */
 
 #define QAT_AUTH_ALGO_BITPOS 0
 /**< @ingroup icp_qat_hw_defs
@@ -1325,7 +1325,7 @@ typedef struct icp_qat_hw_trng_test_status_s
 
 #define QAT_TRNG_TEST_STATUS_MASK 0x1
 /**< @ingroup icp_qat_hw_defs
- * Mask of one bit used to determine the TRNG Test staus */
+ * Mask of one bit used to determine the TRNG Test status */
 
 #define QAT_TRNG_TEST_STATUS_BITPOS 1
 /**< @ingroup icp_qat_hw_defs

--- a/quickassist/utilities/libusdm_drv/include/qae_mem_utils.h
+++ b/quickassist/utilities/libusdm_drv/include/qae_mem_utils.h
@@ -602,7 +602,7 @@ uint64_t qaeIOMMUVirtToPhys(uint64_t iova);
  * @description
  *      This function attaches a pci dev (VF) to an iommu domain.
  *      Applicable when IOMMU/SRIOV are enabled and after the driver bringup
- *      in Host is succesful.
+ *      in Host is successful.
  *
  * @param[in] dev, Device to be attached
  *
@@ -612,7 +612,7 @@ uint64_t qaeIOMMUVirtToPhys(uint64_t iova);
  *
  * @pre
  *      An iommu domain is created using qaeIOMMUInit. Driver bringup
- *      in Host is succesful.
+ *      in Host is successful.
  * @post
  *       device is attached
  *
@@ -632,7 +632,7 @@ int32_t qaeIOMMUAttachDev(void *dev);
  *
  * @pre
  *      An iommu domain is created using qaeIOMMUInit, Driver bringup
- *      in Host is succesful and dev is already
+ *      in Host is successful and dev is already
  *      attached using qaeIOMMUAttachDev
  * @post
  *      Device is detached

--- a/quickassist/utilities/libusdm_drv/qae_mem.h
+++ b/quickassist/utilities/libusdm_drv/qae_mem.h
@@ -87,7 +87,7 @@ extern "C" {
  *
  * @brief
  *      When used in user space, allocates memsize bytes of virtual memory.
- *      When used in kernel space, allocates memsize bytes of contigous and
+ *      When used in kernel space, allocates memsize bytes of contiguous and
  *      pinned memory.
  *
  * @param[in] memsize - the amount of memory in bytes to be allocated

--- a/quickassist/utilities/libusdm_drv/user_space/qae_mem_utils_common.c
+++ b/quickassist/utilities/libusdm_drv/user_space/qae_mem_utils_common.c
@@ -561,7 +561,7 @@ void __qae_free_slab(const int fd, dev_mem_info_t *slab)
     del_slab_from_hash(slab);
 
     memcpy(&memInfo, slab, sizeof(dev_mem_info_t));
-    /* Need to disconnect from orignal chain */
+    /* Need to disconnect from original chain */
     ret = qae_munmap(memInfo.virt_addr, memInfo.size);
     if (ret)
     {

--- a/quickassist/utilities/libusdm_drv/user_space/vfio/qae_mem_utils_vfio.c
+++ b/quickassist/utilities/libusdm_drv/user_space/vfio/qae_mem_utils_vfio.c
@@ -66,13 +66,13 @@
  * This file provides for Linux user space memory allocation. It uses
  * a driver that allocates the memory in kernel memory space (to ensure
  * physically contiguous memory) and maps it to
- * user space for use by the QuickAssist libaries and their users
+ * user space for use by the QuickAssist libraries and their users
  *
  ***************************************************************************/
 #include <linux/vfio.h>
 #include "qae_mem_utils_common.h"
 
-/* Check for process pid caching availibility */
+/* Check for process pid caching availability */
 #ifdef MADV_WIPEONFORK
 #define CACHE_PID
 #endif
@@ -489,7 +489,7 @@ static int filter_dma_ranges(int fd)
     if (!iommu_info)
     {
         CMD_ERROR(
-            "%s:%d Allocaton failed for iommu_info\n", __func__, __LINE__);
+            "%s:%d Allocation failed for iommu_info\n", __func__, __LINE__);
         return -1;
     }
 

--- a/quickassist/utilities/osal/include/Osal.h
+++ b/quickassist/utilities/osal/include/Osal.h
@@ -1671,8 +1671,8 @@ osalHashSHA512Full(UINT8 *in, UINT8 *out, UINT32 len);
  *
  * @brief  Single block AES encrypt
  *
- * @param  key - pointer to symetric key.
- *         keyLenInBytes - key lenght
+ * @param  key - pointer to symmetric key.
+ *         keyLenInBytes - key length
  *         in - pointer to data to encrypt
  *         out - pointer to output buffer for encrypted text
  *         The in and out buffers need to be at least AES block size long
@@ -1692,7 +1692,7 @@ osalAESEncrypt(UINT8 *key, UINT32 keyLenInBytes, UINT8 *in, UINT8 *out);
  *
  * @brief  Converts AES forward key to reverse key
  *
- * @param  key - pointer to symetric key.
+ * @param  key - pointer to symmetric key.
  *         keyLenInBytes - key length
  *         out - pointer to output buffer for reversed key
  *         The in and out buffers need to be at least AES block size long
@@ -1743,7 +1743,7 @@ void osalCryptoInterfaceExit(void);
         * @brief  Function adds mapping from io virtual address
         *         to a physical address.
         *
-        * @param  in - Host phisical address.
+        * @param  in - Host physical address.
         *         in - IO virtual address.
         *         in - Memory size to be remapped obtained from
         *              osalIOMMUgetRemappingSize() function.

--- a/quickassist/utilities/osal/include/OsalDevDrvCommon.h
+++ b/quickassist/utilities/osal/include/OsalDevDrvCommon.h
@@ -73,8 +73,8 @@ extern "C" {
 #endif
 
 #include "OsalOsTypes.h"
-#pragma pack(push) /* Push the current alignement on the stack */
-#pragma pack(1)    /* Force alignement on 1 byte to support 32                 \
+#pragma pack(push) /* Push the current alignment on the stack */
+#pragma pack(1)    /* Force alignment on 1 byte to support 32                 \
                       bits user space on 64 bits kernels */
 /* Number of allocated pages for memory managements
  * For kernel which can allocate 4M, then value can be 512
@@ -95,7 +95,7 @@ extern "C" {
 /* magic used to identify double length
  * Need to bigger than 2 of ICP_NUM_PAGES_PER_ALLOC
  * The reason is that we will mmap 2*ICP_NUM_PAGES_PER_ALLOC
- * to achive page alignement, and this macro is used when
+ * to achieve page alignment, and this macro is used when
  * user really wants to mmap 2*ICP_NUM_PAGES_PER_ALLOC pages
  */
 #define ICP_MMAP_DOUBLE_NUM_PAGES 2048
@@ -155,7 +155,7 @@ typedef struct dev_iommu_info_s
     uint64_t iova;
     uint64_t size;
 } dev_iommu_info_t;
-#pragma pack(pop) /*Restore Previous alignement*/
+#pragma pack(pop) /* Restore Previous alignment */
 
 typedef struct user_proc_mem_list_s
 {

--- a/quickassist/utilities/osal/src/linux/user_space/OsalCryptoInterface.c
+++ b/quickassist/utilities/osal/src/linux/user_space/OsalCryptoInterface.c
@@ -128,7 +128,7 @@ osalHashSHA1Full(UINT8 *in, UINT8 *out, UINT32 len)
     UPDATE(SHA1)(&ctx, in, len);
     FINAL(SHA1)(out, &ctx);
     memcpy(out, &ctx, SHA_DIGEST_LENGTH);
-    /* Change output endianess for SHA1 algorithm */
+    /* Change output endianness for SHA1 algorithm */
     for (i = 0; i < (SHA_DIGEST_LENGTH >> 2); i++)
     {
         ((UINT32 *)(out))[i] = OSAL_HOST_TO_NW_32(((UINT32 *)(out))[i]);
@@ -175,7 +175,7 @@ osalHashSHA256Full(UINT8 *in, UINT8 *out, UINT32 len)
     FINAL(SHA256)(out, &ctx);
     memcpy(out, &ctx, SHA256_DIGEST_LENGTH);
 
-    /* Change output endianess for SHA256 algorithm */
+    /* Change output endianness for SHA256 algorithm */
     for (i = 0; i < (SHA256_DIGEST_LENGTH >> 2); i++)
     {
         ((UINT32 *)(out))[i] = OSAL_HOST_TO_NW_32(((UINT32 *)(out))[i]);
@@ -210,7 +210,7 @@ osalHashSHA384Full(UINT8 *in, UINT8 *out, UINT32 len)
     UPDATE(SHA384)(&ctx, in, len);
     FINAL(SHA384)(out, &ctx);
     memcpy(out, &ctx, SHA384_DIGEST_LENGTH);
-    /* Change output endianess for SHA1 algorithm */
+    /* Change output endianness for SHA1 algorithm */
     for (i = 0; i < (SHA384_DIGEST_LENGTH >> 3); i++)
     {
         ((UINT64 *)(out))[i] = OSAL_HOST_TO_NW_64(((UINT64 *)(out))[i]);
@@ -244,7 +244,7 @@ osalHashSHA512Full(UINT8 *in, UINT8 *out, UINT32 len)
     UPDATE(SHA512)(&ctx, in, len);
     FINAL(SHA512)(out, &ctx);
     memcpy(out, &ctx, SHA512_DIGEST_LENGTH);
-    /* Change output endianess for SHA512 algorithm */
+    /* Change output endianness for SHA512 algorithm */
     for (i = 0; i < (SHA512_DIGEST_LENGTH >> 3); i++)
     {
         ((UINT64 *)(out))[i] = OSAL_HOST_TO_NW_64(((UINT64 *)(out))[i]);

--- a/quickassist/utilities/osal/src/linux/user_space/OsalSemaphore.c
+++ b/quickassist/utilities/osal/src/linux/user_space/OsalSemaphore.c
@@ -55,7 +55,7 @@ OSAL_PUBLIC OSAL_STATUS osalSemaphoreInit(OsalSemaphore *sid,
     OSAL_LOCAL_ENSURE(
         sid, "osalSemaphoreInit():   Null semaphore pointer", OSAL_FAIL);
     /*
-     *  Allocate memory for the sempahore object.
+     *  Allocate memory for the semaphore object.
      */
     *sid = osalMemAlloc(sizeof(sem_t));
     if (!(*sid))
@@ -207,7 +207,7 @@ OSAL_PUBLIC OSAL_STATUS osalSemaphoreDestroy(OsalSemaphore *sid)
     OSAL_LOCAL_ENSURE(
         sid, "osalSemaphoreDestroy():   Null semaphore pointer", OSAL_FAIL);
     /*
-     * Destory the semaphore object.
+     * Destroy the semaphore object.
      */
     status = sem_destroy(*sid);
 

--- a/quickassist/utilities/osal/src/linux/user_space/OsalServices.c
+++ b/quickassist/utilities/osal/src/linux/user_space/OsalServices.c
@@ -216,16 +216,16 @@ void *osalMemAllocAtomic(UINT32 size)
 /*
  * MemAlloc with Alignment API:
  * Make sure memory is aligned to alignment ( passed as last parameter)
- * This function is maintained for backward compatibiltiy
+ * This function is maintained for backward compatibility
  * IDS team has requested not to touch this code, as this is in working
  condition.
- * another implementaion of this function can be found in API
+ * another implementation of this function can be found in API
  * "void * _OsalMemAllocAlligned(unsigned int size, unsigned int alignment)"
  *
- * return - Pointer to requested alligned memory.
+ * return - Pointer to requested aligned memory.
  * in - space  (unknown....why?)
       - size need to malloc
- *    - allignement required ( 4, 8....256)
+ *    - alignment required ( 4, 8....256)
  *
  */
 void *osalMemAllocAligned(UINT32 space, UINT32 size, UINT32 alignment)

--- a/quickassist/utilities/osal/src/linux/user_space/OsalThread.c
+++ b/quickassist/utilities/osal/src/linux/user_space/OsalThread.c
@@ -64,7 +64,7 @@ OSAL_PUBLIC OSAL_STATUS osalThreadCreate(OsalThread *thread,
         osalLog(OSAL_LOG_LVL_ERROR,
                 OSAL_LOG_DEV_STDOUT,
                 "\nosalThreadCreate:"
-                "Failed to initialize Thread Attributes !!!\n");
+                "Failed to initialize Thread Attributes!\n");
 
         return OSAL_FAIL;
     }
@@ -81,7 +81,7 @@ OSAL_PUBLIC OSAL_STATUS osalThreadCreate(OsalThread *thread,
             osalLog(OSAL_LOG_LVL_ERROR,
                     OSAL_LOG_DEV_STDOUT,
                     "\nosalThreadCreate:"
-                    "Failed to set inherit sched for thread!!!\n");
+                    "Failed to set inherit sched for thread!\n");
             pthread_attr_destroy(&attr);
             return OSAL_FAIL;
         }
@@ -92,7 +92,7 @@ OSAL_PUBLIC OSAL_STATUS osalThreadCreate(OsalThread *thread,
             osalLog(OSAL_LOG_LVL_ERROR,
                     OSAL_LOG_DEV_STDOUT,
                     "\nosalThreadCreate:"
-                    "Failed to set scheduling policy for thread !!!\n");
+                    "Failed to set scheduling policy for thread!\n");
             pthread_attr_destroy(&attr);
             return OSAL_FAIL;
         }
@@ -106,7 +106,7 @@ OSAL_PUBLIC OSAL_STATUS osalThreadCreate(OsalThread *thread,
             osalLog(OSAL_LOG_LVL_ERROR,
                     OSAL_LOG_DEV_STDOUT,
                     "\nosalThreadCreate:"
-                    "Failed to set the sched parameters atribute !!!\n");
+                    "Failed to set the sched parameters attribute!\n");
             pthread_attr_destroy(&attr);
             return OSAL_FAIL;
         }
@@ -131,7 +131,7 @@ OSAL_PUBLIC OSAL_STATUS osalThreadCreate(OsalThread *thread,
             osalLog(OSAL_LOG_LVL_ERROR,
                     OSAL_LOG_DEV_STDOUT,
                     "\nosalThreadCreate:"
-                    "Failed to set inherit sched for thread!!!\n");
+                    "Failed to set inherit sched for thread!\n");
             pthread_attr_destroy(&attr);
             return OSAL_FAIL;
         }
@@ -141,7 +141,7 @@ OSAL_PUBLIC OSAL_STATUS osalThreadCreate(OsalThread *thread,
             osalLog(OSAL_LOG_LVL_ERROR,
                     OSAL_LOG_DEV_STDOUT,
                     "\nosalThreadCreate:"
-                    "Failed to set scheduling policy for thread !!!\n");
+                    "Failed to set scheduling policy for thread!\n");
             pthread_attr_destroy(&attr);
             return OSAL_FAIL;
         }
@@ -157,7 +157,7 @@ OSAL_PUBLIC OSAL_STATUS osalThreadCreate(OsalThread *thread,
                 osalLog(OSAL_LOG_LVL_ERROR,
                         OSAL_LOG_DEV_STDOUT,
                         "\nosalThreadCreate:"
-                        "Failed to set the sched parameters atribute !!!\n");
+                        "Failed to set the sched parameters attribute!\n");
                 pthread_attr_destroy(&attr);
                 return OSAL_FAIL;
             }
@@ -172,7 +172,7 @@ OSAL_PUBLIC OSAL_STATUS osalThreadCreate(OsalThread *thread,
         osalLog(OSAL_LOG_LVL_ERROR,
                 OSAL_LOG_DEV_STDOUT,
                 "\nosalThreadCreate:"
-                "Failed to set the dettachState attribute !!!\n");
+                "Failed to set the dettachState attribute!\n");
         pthread_attr_destroy(&attr);
         return OSAL_FAIL;
     }
@@ -181,7 +181,7 @@ OSAL_PUBLIC OSAL_STATUS osalThreadCreate(OsalThread *thread,
     {
         osalLog(OSAL_LOG_LVL_ERROR,
                 OSAL_LOG_DEV_STDOUT,
-                "\nosalThreadCreate: Failed to set the attribute !!!\n");
+                "\nosalThreadCreate: Failed to set the attribute!\n");
         pthread_attr_destroy(&attr);
         return OSAL_FAIL;
     }
@@ -287,7 +287,7 @@ OSAL_PUBLIC OSAL_STATUS osalThreadStart(OsalThread *thread)
 
     osalLog(OSAL_LOG_LVL_DEBUG3,
             OSAL_LOG_DEV_STDOUT,
-            "\nosalThreadStart: Nothing to be done !!\n");
+            "\nosalThreadStart: Nothing to be done!\n");
 
     return OSAL_SUCCESS;
 }
@@ -329,7 +329,7 @@ OSAL_PUBLIC OSAL_STATUS osalThreadPrioritySet(OsalThread *thread,
     {
         osalLog(OSAL_LOG_LVL_ERROR,
                 OSAL_LOG_DEV_STDOUT,
-                "osalThreadPrioritySet(): could not get sched param !!!\n");
+                "osalThreadPrioritySet(): could not get sched param!\n");
         return OSAL_FAIL;
     }
 
@@ -340,7 +340,7 @@ OSAL_PUBLIC OSAL_STATUS osalThreadPrioritySet(OsalThread *thread,
     {
         osalLog(OSAL_LOG_LVL_ERROR,
                 OSAL_LOG_DEV_STDOUT,
-                "osalThreadPrioritySet(): Erroneous priority !!!\n");
+                "osalThreadPrioritySet(): Erroneous priority!\n");
         return OSAL_FAIL;
     }
 
@@ -385,7 +385,7 @@ OSAL_PUBLIC OSAL_STATUS osalThreadSetPolicyAndPriority(OsalThread *thread,
         osalLog(
             OSAL_LOG_LVL_ERROR,
             OSAL_LOG_DEV_STDOUT,
-            "osalThreadSetPolicyAndPriority(): invalid value for policy!!! \n");
+            "osalThreadSetPolicyAndPriority(): invalid value for policy!\n");
 
         return OSAL_FAIL;
     }
@@ -396,8 +396,8 @@ OSAL_PUBLIC OSAL_STATUS osalThreadSetPolicyAndPriority(OsalThread *thread,
     {
         osalLog(OSAL_LOG_LVL_ERROR,
                 OSAL_LOG_DEV_STDOUT,
-                "osalThreadSetPolicyAndPriority(): could not get sched param "
-                "!!!\n");
+                "osalThreadSetPolicyAndPriority(): could not get sched param"
+                "!\n");
         return OSAL_FAIL;
     }
 
@@ -408,7 +408,7 @@ OSAL_PUBLIC OSAL_STATUS osalThreadSetPolicyAndPriority(OsalThread *thread,
     {
         osalLog(OSAL_LOG_LVL_ERROR,
                 OSAL_LOG_DEV_STDOUT,
-                "osalThreadPrioritySet(): Errorneous priority !!!\n");
+                "osalThreadPrioritySet(): Erroneous priority!\n");
 
         return OSAL_FAIL;
     }
@@ -421,7 +421,7 @@ OSAL_PUBLIC OSAL_STATUS osalThreadSetPolicyAndPriority(OsalThread *thread,
         osalLog(OSAL_LOG_LVL_ERROR,
                 OSAL_LOG_DEV_STDOUT,
                 "osalThreadSetPolicyAndPriority:"
-                "Policy and Priority Set operation failed!!! \n");
+                "Policy and Priority Set operation failed!\n");
         return OSAL_FAIL;
     }
 #endif

--- a/quickassist/utilities/osal/src/linux/user_space/OsalUsrKrnProxy.c
+++ b/quickassist/utilities/osal/src/linux/user_space/OsalUsrKrnProxy.c
@@ -816,7 +816,7 @@ OSAL_PUBLIC void *osalMemAllocContiguousNUMA(UINT32 size,
         return NULL;
     }
 
-/* available size needs to substract current size and header */
+/* available size needs to subtract current size and header */
 /* As DMA remapping may add extra page, so we need to use alloc_size
    instead of the size in pMemInfo structure */
 #ifdef ICP_SRIOV


### PR DESCRIPTION
There are a wide range of spelling mistakes and typos in comments and also error messages as found using codespell. Fix these.
