### PR TITLE
Add pkg-config to compilation dependencies

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -227,6 +227,7 @@ Compilation and installation - detailed instructions
             gcc
             make
             autotools (automake, autoconf, libtool)
+            pkg-config
             systemd-devel
             nasm
         Note: If nasm compiler is unavailable see


### PR DESCRIPTION
pkg-config is necessary for systemd support, see:
https://github.com/intel/qatlib/blob/7429ee2b7c837137ed11959a3c2cc3729dc15739/configure.ac#L99-L110

Without pkg-config, this project will build even when configured with `--enable-service` (config.log will contain 'check for systemd pkg-config support: no' though) but when trying to run `sudo make install`, it will fail when trying to start the service since it won't actually copy the generated service file.