### PR TITLE
Update in documentation - in INSTALL file

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -431,7 +431,9 @@ Compilation and installation - detailed instructions
                 will be allocated one VF from each PF, so 4 VFs. It will have
                 2 sym;asym VFs, so 4 sym instances and 4 asym instances
                 and 2 dc VFs, so 8 dc instances.
-                The maximum number of processes is 8. N sockets will have 8 * N.
+                The maximum number of processes is 16. With N sockets,
+                the maximum number of processes is still 16, each will have
+                instances as above * N.
 
             Scalability and flexibility
                 POLICY=2. ServicesEnabled unset. Each process will be


### PR DESCRIPTION
Update in the description for the default configuration in the Configuration and Tuning section. A correction is made in the maximum number of processes.

As for POLICY 0, the maximum number of processes will be always 16 regardless of number of sockets!

i.e. for POLICY = 0, each process gets 1 VF from each PF; for 1S we have 16 VFs * 4 PFs = 64 VFs; one process can take 4 VF so a maximum of 16 (64 / 4) number of processes are possible; for 2S we have 16 VFs * 8 PFs = 128 VF; so a maximum of 16 (128 / 8) number of processes are possible.

Correction is made based on the details above.