### PR TITLE
Don't default to treating compiler warnings as errors.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 
 AC_PREREQ([2.69])
 AC_INIT([qatlib], [24.09.0], [qat-linux@intel.com])
-AM_INIT_AUTOMAKE([-Wall -Werror -Wno-portability foreign subdir-objects tar-pax])
+AM_INIT_AUTOMAKE([-Wall -Wno-portability foreign subdir-objects tar-pax])
 
 AM_SILENT_RULES([yes])
 AC_USE_SYSTEM_EXTENSIONS


### PR DESCRIPTION
Compilers evolve and future versions may throw warnings that don't show up today. Treating all warnings as errors is helpful at development stage, but best removed in released code to avoid the potential of such future warnings breaking the build.

So remove the -Werror flag.