### PR TITLE
QAT20-39104: Resources should be managed based on process id

### DIFF
--- a/quickassist/lookaside/access_layer/src/qat_direct/vfio/qat_mgr.h
+++ b/quickassist/lookaside/access_layer/src/qat_direct/vfio/qat_mgr.h
@@ -242,7 +242,7 @@ struct qatmgr_section_data
 {
     char section_name[QATMGR_MAX_STRLEN];
     char base_name[QATMGR_MAX_STRLEN];
-    pthread_t assigned_tid;
+    pthread_t assigned_pid;
     int num_devices;
     struct qatmgr_device_data *device_data;
 };
@@ -341,10 +341,10 @@ bool qat_mgr_is_dev_available(void);
 int handle_message(struct qatmgr_msg_req *req,
                    struct qatmgr_msg_rsp *rsp,
                    char **section_name,
-                   pid_t tid,
+                   pid_t pid,
                    int *index);
 
-int release_section(int index, pthread_t tid, char *name, size_t name_len);
+int release_section(int index, pthread_t pid, char *name, size_t name_len);
 int init_section_data_mutex(void);
 int destroy_section_data_mutex(void);
 

--- a/quickassist/lookaside/access_layer/src/qat_direct/vfio/qat_mgr_client.c
+++ b/quickassist/lookaside/access_layer/src/qat_direct/vfio/qat_mgr_client.c
@@ -239,7 +239,7 @@ int qatmgr_query(struct qatmgr_msg_req *req,
     int size_rx = 0;
     ssize_t numchars;
     static int index = -1;
-    pid_t tid = pthread_self();
+    pid_t pid = getpid();
     static char *section_name = NULL;
 
     ICP_CHECK_FOR_NULL_PARAM_RET_CODE(req, -1);
@@ -276,7 +276,7 @@ int qatmgr_query(struct qatmgr_msg_req *req,
     req->hdr.len = sizeof(req->hdr) + size_tx;
 
     if (qatmgr_sock < 0)
-        return handle_message(req, rsp, &section_name, tid, &index);
+        return handle_message(req, rsp, &section_name, pid, &index);
 
     osalMutexLock(&qatmgr_mutex, OSAL_WAIT_FOREVER);
 


### PR DESCRIPTION
QAT instances should be allocated to a user process based on the process id and not on the basis of thread id. This is because multiple threads within a process may share QAT resources.