### PR TITLE
Add zuc_sample to git ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ build
 /qatlib.spec
 quickassist/utilities/service/qat_init.sh
 /sym_dp_sample
+/zuc_sample


### PR DESCRIPTION
Zuc_sample should be added to the git ignore list in the same manner as already done for other sample applications.