### PR TITLE
Update license header format

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-  SPDX-License-Identifier: BSD-3-Clause
+  BSD-3-Clause License
 
   Copyright(c) 2007-2025 Intel Corporation.
   All rights reserved.


### PR DESCRIPTION
Remove the unnecessary text before the license name as that format is not recognised by the OSSF scorecard algorithm.