### PR TITLE
qat_init: fix check_driver() multi-module Live state comparison

### DIFF
--- a/quickassist/utilities/service/qat_init.sh.in
+++ b/quickassist/utilities/service/qat_init.sh.in
@@ -113,7 +113,7 @@ check_driver() {
     ATTEMPT_CNT=0
     CURRENT_STATE=$(get_module_state)
 
-    while [ "$CURRENT_STATE" != "Live" ]
+    while ! echo "$CURRENT_STATE" | grep -q "^Live$"
     do
         if [ $ATTEMPT_CNT -ge $TIMEOUT_CNT ]; then
             TIMEOUT=$(awk "BEGIN {print $ATTEMPT_CNT * $ATTEMPT_INTERVAL}")


### PR DESCRIPTION
When both qat_4xxx and qat_420xx modules are loaded (which happens on 420xx hardware even though qat_4xxx has no devices bound), get_module_state()
returns two lines of output. The previous string equality check

   while [ "$CURRENT_STATE" != "Live" ]

never matched because "Live\nLive" != "Live", causing the service to spin for the full 20-second timeout and exit with:

   QAT driver is still not present after 20s. Aborting qat_init

Replace the equality check with a grep that succeeds as soon as any driver in the output reaches the Live state, which is the correct signal that the relevant hardware driver is ready to proceed.

This PR resolves #149 