### PR TITLE
qat_init: fix qat.service timeout with multiple drivers

### DIFF
--- a/quickassist/utilities/service/qat_init.sh.in
+++ b/quickassist/utilities/service/qat_init.sh.in
@@ -88,7 +88,7 @@ get_module_state() {
     do
         CMD="$CMD -e ^$SUPPORTED_DRIVER_NAME"
     done
-    echo "$(cat /proc/modules | grep $CMD | cut -d' ' -f5)"
+    echo "$(cat /proc/modules | grep $CMD | cut -d' ' -f5 | sort -u)"
 }
 
 check_driver() {


### PR DESCRIPTION
When multiple QAT drivers are loaded (e.g. qat_4xxx and qat_420xx), get_module_state() returns one "Live" line per module. The check_driver() comparison:

    while [ "$CURRENT_STATE" != "Live" ]

fails because "Live\nLive" never equals "Live", causing qat_init to loop until the 20-second timeout and abort.

Add sort -u to deduplicate the module state output so that when all loaded drivers report "Live", the result collapses to a single "Live" and the comparison succeeds. If any module is in a different state, the deduplicated output remains multi-line and the wait loop continues correctly.